### PR TITLE
[HOLD: WORKING ON IMPORT SIDE] This commit will give users the options to create a module for their blueprint export.

### DIFF
--- a/oa_export.batch.export.inc
+++ b/oa_export.batch.export.inc
@@ -10,42 +10,78 @@ define('BLUEPRINT_SPACE', 'field_oa_clone_space');
  *
  * @param object $blueprint
  *   The fully loaded blueprint entity.
+ * @param string $export_type
+ *   Defaults to 'file' but could also be 'module'.
  */
-function oa_export_batch_export($blueprint) {
+function oa_export_batch_export($blueprint, $export_type = 'file') {
 
-  // Store space data in session.
-  $_SESSION['oa_export'] = array();
+  switch ($export_type) {
+    case 'file':
+      $_SESSION['oa_export'] = array();
 
-  // Store the path we will link to after download.
-  $_SESSION['oa_export']['redirect'] = 'admin/structure/taxonomy/space_type';
+      // Store the path we will link to after download.
+      $_SESSION['oa_export']['redirect'] = 'admin/structure/taxonomy/space_type';
 
-  // Store the export directory in the session variable.
-  $_SESSION['oa_export']['directory'] = oa_export_create_temp_directory($blueprint->name);
+      // Store the export directory in the session variable.
+      if ($_SESSION['oa_export']['directory'] = oa_export_create_temp_export_directory($blueprint->name)) {
+        // Setup a directory for exporting files.
+        if (oa_export_create_directories($_SESSION['oa_export']['directory'] . '/files')) {
+          $_SESSION['oa_export']['files_directory'] = $_SESSION['oa_export']['directory'] . '/files';
+        }
+        else {
+          drupal_set_message(t('Could not create @files', array('@files' => $_SESSION['oa_export']['directory'] . '/files')), 'error');
+          oa_export_cleanup($_SESSION['oa_export']['directory'], $_SESSION['oa_export']['redirect']);
+        }
 
-  // Setup a directory for exporting files.
-  $_SESSION['oa_export']['files_directory'] = oa_export_create_sub_directory($_SESSION['oa_export']['directory'], 'files');
+        // Temporary directory for system.
+        $tmp_dir = sys_get_temp_dir();
+        if (!is_writable($tmp_dir)) {
+          drupal_set_message(t('In order for this export to work "%dir" needs to be writable.', array('%dir' => $tmp_dir)), 'error');
+          oa_export_cleanup($_SESSION['oa_export']['directory'], $_SESSION['oa_export']['redirect']);
+        }
 
-  $batch = array(
-    'title' => t('Blueprint Export'),
-    'init_message' => t('Preparing to export !name blueprint', array('!name' => $blueprint->name)),
-    'finished' => 'oa_export_batch_export_finished',
-  );
+        $batch = array(
+          'title' => t('Blueprint Download'),
+          'init_message' => t('Preparing to download "!name" blueprint', array('!name' => $blueprint->name)),
+          'finished' => 'oa_export_batch_export_download_finished',
+        );
 
-  // Defines batch operations for the batch.
-  oa_export_batch_export_operations($batch, $blueprint);
+        // Defines batch operations for the batch.
+        oa_export_batch_export_operations($batch, $blueprint);
 
-  // Temporary directory for system.
-  $tmp_dir = sys_get_temp_dir();
-  if (!is_writable($tmp_dir)) {
-    drupal_set_message(t('In order for this export to work "%dir" needs to be writable.', array('%dir' => $tmp_dir)), 'error');
+        batch_set($batch);
+        // Redirect the user to a page to download the file.
+        batch_process('oa_export/download');
+      }
+      else {
+        drupal_set_message(t('Could not create a directory in your system temporary directory.'), 'error');
+        oa_export_cleanup($_SESSION['oa_export']['directory'], $_SESSION['oa_export']['redirect']);
+      }
+      break;
+
+    case 'module':
+      // Store the path we will link to after download.
+      $_SESSION['oa_export']['redirect'] = 'blueprint/export/' . $blueprint->tid
+      ;
+      $batch = array(
+        'title' => t('Blueprint Module Export'),
+        'init_message' => t('Preparing to export the "!name" blueprint to a module.', array('!name' => $blueprint->name)),
+        'finished' => 'oa_export_batch_export_module_finished',
+      );
+
+      // Defines batch operations for the batch.
+      oa_export_batch_export_operations($batch, $blueprint);
+
+      batch_set($batch);
+      break;
+
+    default:
+      break;
   }
-  batch_set($batch);
-  // Redirect the user to a page to download the file.
-  batch_process('oa_export/download');
 }
 
 /**
- * Defines batch operations for the batch.
+ * Defines batch operations for the download batch.
  *
  * @param array $batch
  *   The current batch.

--- a/oa_export.batch.export.inc
+++ b/oa_export.batch.export.inc
@@ -202,7 +202,7 @@ function _oa_export_batch_export_dependency($entity, &$context) {
  * @param $operations
  * @throws Exception
  */
-function oa_export_batch_export_finished($success, $results, $operations) {
+function oa_export_batch_export_download_finished($success, $results, $operations) {
   if ($success) {
 
     try {
@@ -253,10 +253,27 @@ function oa_export_batch_export_finished($success, $results, $operations) {
   }
 }
 
+function oa_export_batch_export_module_finished($success, $results, $operations) {
+  if ($success) {
+    // See if we can get the module path this way at this point.
+    // @todo: We can, so maybe store less variables in session?
+    $module_path = drupal_get_path('module', $results['module']);
+    if (isset($results['export_path'])) {
+      // Create a json file to add to the oa_export directory in our module.
+      $file = oa_export_create_json_export('entities', $results['export'], $results['export_path'] . '/oa_export');
+    }
+  }
+  else {
+    drupal_set_message(t('The batch finished but something went wrong. Try again or contact your system administrator.'));
+    $dir = ($_SESSION['oa_export']['type'] == 'new') ? $_SESSION['oa_export']['module_path'] ? ($_SESSION['oa_export']['type'] == 'existing') : $_SESSION['oa_export']['module_path'] . '/oa_export' : NULL;
+    oa_export_cleanup($dir, $_SESSION['oa_export']['redirect']);
+  }
+}
+
 /**
  * Helper function that handles the file download.
  */
-function oa_export_batch_export_finished_redirect() {
+function oa_export_batch_export_download_finished_redirect() {
 
   if (empty($_SESSION['oa_export']['directory']) || empty($_SESSION['oa_export']['file'])) {
     return t('The file cannot be found.');
@@ -267,15 +284,15 @@ function oa_export_batch_export_finished_redirect() {
   drupal_add_js('setTimeout(function() { window.location.href = "' . $redirect . '"; }, 2000);', 'inline');
 
   // Remove the temporary directory we created.
-  oa_export_remove_temp_directory($_SESSION['oa_export']['directory']);
+  oa_export_remove_directory($_SESSION['oa_export']['directory']);
 
   $output = theme('blueprint_download_page', array());
 
   // Remove the temporary tar file.
   unlink($_SESSION['oa_export']['file']);
 
-  // Get rid of our session variables.
-  unset($_SESSION['oa_export']);
+  // Clean up.
+  oa_export_cleanup();
 
   return $output;
 }

--- a/oa_export.batch.export.inc
+++ b/oa_export.batch.export.inc
@@ -90,16 +90,12 @@ function oa_export_batch_export($blueprint, $export_type = 'file') {
  */
 function oa_export_batch_export_operations(&$batch, $blueprint) {
 
-  // The blueprint.
-  $batch['operations'][] = array('_oa_export_batch_export_blueprint', array($blueprint));
-
-  // Get the entity reference, the space, this blueprint is built on.
+  // Get the entity reference of the space this blueprint is built on.
   $wrapper = entity_metadata_wrapper('taxonomy_term', $blueprint);
   $space = $wrapper->{BLUEPRINT_SPACE}->value();
 
-  // The space should have been exported the blueprint batch operation but the
-  // space can still have other dependencies. e.g., comments.
-  $batch['operations'][] = array('_oa_export_batch_export_dependency', array($space));
+  // The blueprint.
+  $batch['operations'][] = array('_oa_export_batch_export_blueprint', array($blueprint, $space));
 
   // Entities that are sub groups of the space.
   $groups = oa_core_get_groups_by_parent($space->nid, NULL);
@@ -115,14 +111,17 @@ function oa_export_batch_export_operations(&$batch, $blueprint) {
 }
 
 /**
- * A batch operation to export a blueprint.
+ * A batch operation to export a blueprint. We want to export the blueprint but don't want the parents of the space the
+ * blueprint is being built on.
  *
  * @param object $blueprint
  *   The fully loaded blueprint entity.
+ * @param object $space
+ *   The space being exported.
  * @param array $context
  *   Passed around between batch operations.
  */
-function _oa_export_batch_export_blueprint($blueprint, &$context) {
+function _oa_export_batch_export_blueprint($blueprint, $space, &$context) {
 
   // As of now we only allow one blueprint export at a time.
   if (empty($context['sandbox']['max'])) {
@@ -133,8 +132,31 @@ function _oa_export_batch_export_blueprint($blueprint, &$context) {
     $context['results']['total'] = (!empty($context['results']['total']) ? $context['results']['total'] : 0) + $context['sandbox']['max'];
   }
 
-  // Export the entity.
-  oa_export_entity_export('taxonomy_term', $blueprint, $context['results']);
+  // If we have access to this session variable let's store it in the results, this is more stable.
+  if (isset($_SESSION['oa_export']['module_path'])) {
+    $context['results']['export_path'] = $_SESSION['oa_export']['module_path'];
+  }
+  if (isset($_SESSION['oa_export']['module'])) {
+    $context['results']['module'] = $_SESSION['oa_export']['module'];
+  }
+
+  // Store the reference to the space the blueprint is referencing.
+  $space_reference = $blueprint->field_oa_clone_space;
+
+  // Remove the space reference for now so it doesn't get exported yet. We will export it next.
+  $blueprint->field_oa_clone_space = array();
+
+  // Export the blueprint.
+  oa_export_entity_export('taxonomy_term', $blueprint, $results);
+
+  // Put the reference to the space back so we can reference it during our import.
+  $context['results']['export']['taxonomy_term:' . $blueprint->tid]->field_oa_clone_space = $space_reference;
+
+  // Remove the oa_parent_space reference so we don't get this space's parent space and all of its dependencies.
+  $space->oa_parent_space = array();
+
+  // Export the space without reference to its parent space.
+  oa_export_entity_export('node', $space, $context['results']);
 
   // Bump the progress indicator.
   $context['sandbox']['progress']++;

--- a/oa_export.batch.export.inc
+++ b/oa_export.batch.export.inc
@@ -21,36 +21,36 @@ function oa_export_batch_export($blueprint, $export_type = 'file') {
 
       // Store the export directory in the session variable.
       if ($_SESSION['oa_export']['directory'] = oa_export_create_temp_export_directory($blueprint->name, file_directory_temp())) {
-
         // Create the file directory.
-        if (!oa_export_create_directories($_SESSION['oa_export']['directory'] . '/' . OA_EXPORT_FILES)) {
-          // Make sure we successfully create a directory for exporting files.
-          drupal_set_message(t('Could not create @files', array('@files' => $_SESSION['oa_export']['directory'] . '/' . OA_EXPORT_FILES)), 'error');
+        $file_dir = oa_export_create_directories($_SESSION['oa_export']['directory'] . '/' . OA_EXPORT_FILES);
+        if ($file_dir) {
+          // Store the files directory in session. It is needed later when copying files.
+          $_SESSION['oa_export']['files_directory'] = $file_dir;
+
+          // Temporary directory for system. Gets the path of system-appropriate temporary directory.
+          $tmp_dir = file_directory_temp();
+          if (!is_writable($tmp_dir)) {
+            drupal_set_message(t('In order for this export to work "%dir" needs to be writable.', array('%dir' => $tmp_dir)), 'error');
+            oa_export_cleanup($_SESSION['oa_export']['directory'], OA_EXPORT_REDIRECT);
+          }
+
+          $batch = array(
+            'title' => t('Blueprint Download'),
+            'init_message' => t('Preparing to download "!name" blueprint to a file.', array('!name' => $blueprint->name)),
+            'finished' => 'oa_export_batch_file_download_finished',
+          );
+
+          // Defines batch operations for the batch.
+          oa_export_batch_export_operations($batch, $blueprint);
+
+          batch_set($batch);
+          // Redirect the user to a page to download the file.
+          batch_process('oa_export/download');
+        }
+        else {
+          drupal_set_message(t('Could not create @file_dir', array('@file_dir' => $file_dir)), 'error');
           oa_export_cleanup($_SESSION['oa_export']['directory'], OA_EXPORT_REDIRECT);
         }
-
-        // Store the files directory in session. It is needed later when copying files.
-        $_SESSION['oa_export']['files_directory'] = $_SESSION['oa_export']['directory'] . '/' . OA_EXPORT_FILES;
-
-        // Temporary directory for system. Gets the path of system-appropriate temporary directory.
-        $tmp_dir = file_directory_temp();
-        if (!is_writable($tmp_dir)) {
-          drupal_set_message(t('In order for this export to work "%dir" needs to be writable.', array('%dir' => $tmp_dir)), 'error');
-          oa_export_cleanup($_SESSION['oa_export']['directory'], OA_EXPORT_REDIRECT);
-        }
-
-        $batch = array(
-          'title' => t('Blueprint Download'),
-          'init_message' => t('Preparing to download "!name" blueprint to a file.', array('!name' => $blueprint->name)),
-          'finished' => 'oa_export_batch_file_download_finished',
-        );
-
-        // Defines batch operations for the batch.
-        oa_export_batch_export_operations($batch, $blueprint);
-
-        batch_set($batch);
-        // Redirect the user to a page to download the file.
-        batch_process('oa_export/download');
       }
       else {
         drupal_set_message(t('Could not create a directory in your system temporary directory.'), 'error');

--- a/oa_export.batch.export.inc
+++ b/oa_export.batch.export.inc
@@ -11,7 +11,8 @@ define('BLUEPRINT_SPACE', 'field_oa_clone_space');
  * @param object $blueprint
  *   The fully loaded blueprint entity.
  * @param string $export_type
- *   Defaults to 'file' but could also be 'module'.
+ *   Defaults to 'file' but could also be 'module'. This will allow to define different types of exports when
+ *   triggering an export.
  */
 function oa_export_batch_export($blueprint, $export_type = 'file') {
 

--- a/oa_export.batch.export.inc
+++ b/oa_export.batch.export.inc
@@ -20,7 +20,7 @@ function oa_export_batch_export($blueprint, $export_type = 'file') {
     case 'file':
       $_SESSION['oa_export'] = array();
 
-      // Store the path we will link to after download.
+      // Store the path we will link to after the file download.
       $_SESSION['oa_export']['redirect'] = 'admin/structure/taxonomy/space_type';
 
       // Store the export directory in the session variable.
@@ -43,8 +43,8 @@ function oa_export_batch_export($blueprint, $export_type = 'file') {
 
         $batch = array(
           'title' => t('Blueprint Download'),
-          'init_message' => t('Preparing to download "!name" blueprint', array('!name' => $blueprint->name)),
-          'finished' => 'oa_export_batch_export_download_finished',
+          'init_message' => t('Preparing to download "!name" blueprint to a file.', array('!name' => $blueprint->name)),
+          'finished' => 'oa_export_batch_file_download_finished',
         );
 
         // Defines batch operations for the batch.
@@ -61,13 +61,13 @@ function oa_export_batch_export($blueprint, $export_type = 'file') {
       break;
 
     case 'module':
-      // Store the path we will link to after download.
+      // Store the path we will link to after module creation.
       $_SESSION['oa_export']['redirect'] = 'blueprint/export/' . $blueprint->tid
       ;
       $batch = array(
         'title' => t('Blueprint Module Export'),
         'init_message' => t('Preparing to export the "!name" blueprint to a module.', array('!name' => $blueprint->name)),
-        'finished' => 'oa_export_batch_export_module_finished',
+        'finished' => 'oa_export_batch_module_export_finished',
       );
 
       // Defines batch operations for the batch.
@@ -82,7 +82,7 @@ function oa_export_batch_export($blueprint, $export_type = 'file') {
 }
 
 /**
- * Defines batch operations for the download batch.
+ * Defines batch operations for the file download batch.
  *
  * @param array $batch
  *   The current batch.
@@ -203,7 +203,7 @@ function _oa_export_batch_export_dependency($entity, &$context) {
  * @param $operations
  * @throws Exception
  */
-function oa_export_batch_export_download_finished($success, $results, $operations) {
+function oa_export_batch_file_download_finished($success, $results, $operations) {
   if ($success) {
 
     try {
@@ -254,7 +254,7 @@ function oa_export_batch_export_download_finished($success, $results, $operation
   }
 }
 
-function oa_export_batch_export_module_finished($success, $results, $operations) {
+function oa_export_batch_module_export_finished($success, $results, $operations) {
   if ($success) {
     // See if we can get the module path this way at this point.
     // @todo: We can, so maybe store less variables in session?
@@ -274,7 +274,7 @@ function oa_export_batch_export_module_finished($success, $results, $operations)
 /**
  * Helper function that handles the file download.
  */
-function oa_export_batch_export_download_finished_redirect() {
+function oa_export_batch_file_download_finished_redirect() {
 
   if (empty($_SESSION['oa_export']['directory']) || empty($_SESSION['oa_export']['file'])) {
     return t('The file cannot be found.');

--- a/oa_export.batch.export.inc
+++ b/oa_export.batch.export.inc
@@ -3,8 +3,6 @@
 require_once 'oa_export.entity.export.inc';
 require_once 'oa_export.fields.export.inc';
 
-define('BLUEPRINT_SPACE', 'field_oa_clone_space');
-
 /**
  * Prepare the export and create a batch process.
  *
@@ -18,27 +16,27 @@ function oa_export_batch_export($blueprint, $export_type = 'file') {
 
   switch ($export_type) {
     case 'file':
+      // Start storing session variables for file download.
       $_SESSION['oa_export'] = array();
 
-      // Store the path we will link to after the file download.
-      $_SESSION['oa_export']['redirect'] = 'admin/structure/taxonomy/space_type';
-
       // Store the export directory in the session variable.
-      if ($_SESSION['oa_export']['directory'] = oa_export_create_temp_export_directory($blueprint->name)) {
-        // Setup a directory for exporting files.
-        if (oa_export_create_directories($_SESSION['oa_export']['directory'] . '/files')) {
-          $_SESSION['oa_export']['files_directory'] = $_SESSION['oa_export']['directory'] . '/files';
-        }
-        else {
-          drupal_set_message(t('Could not create @files', array('@files' => $_SESSION['oa_export']['directory'] . '/files')), 'error');
-          oa_export_cleanup($_SESSION['oa_export']['directory'], $_SESSION['oa_export']['redirect']);
+      if ($_SESSION['oa_export']['directory'] = oa_export_create_temp_export_directory($blueprint->name, file_directory_temp())) {
+
+        // Create the file directory.
+        if (!oa_export_create_directories($_SESSION['oa_export']['directory'] . '/' . OA_EXPORT_FILES)) {
+          // Make sure we successfully create a directory for exporting files.
+          drupal_set_message(t('Could not create @files', array('@files' => $_SESSION['oa_export']['directory'] . '/' . OA_EXPORT_FILES)), 'error');
+          oa_export_cleanup($_SESSION['oa_export']['directory'], OA_EXPORT_REDIRECT);
         }
 
-        // Temporary directory for system.
-        $tmp_dir = sys_get_temp_dir();
+        // Store the files directory in session. It is needed later when copying files.
+        $_SESSION['oa_export']['files_directory'] = $_SESSION['oa_export']['directory'] . '/' . OA_EXPORT_FILES;
+
+        // Temporary directory for system. Gets the path of system-appropriate temporary directory.
+        $tmp_dir = file_directory_temp();
         if (!is_writable($tmp_dir)) {
           drupal_set_message(t('In order for this export to work "%dir" needs to be writable.', array('%dir' => $tmp_dir)), 'error');
-          oa_export_cleanup($_SESSION['oa_export']['directory'], $_SESSION['oa_export']['redirect']);
+          oa_export_cleanup($_SESSION['oa_export']['directory'], OA_EXPORT_REDIRECT);
         }
 
         $batch = array(
@@ -56,13 +54,13 @@ function oa_export_batch_export($blueprint, $export_type = 'file') {
       }
       else {
         drupal_set_message(t('Could not create a directory in your system temporary directory.'), 'error');
-        oa_export_cleanup($_SESSION['oa_export']['directory'], $_SESSION['oa_export']['redirect']);
+        oa_export_cleanup($_SESSION['oa_export']['directory'], OA_EXPORT_REDIRECT);
       }
       break;
 
     case 'module':
-      // Store the path we will link to after module creation.
-      $_SESSION['oa_export']['redirect'] = 'blueprint/export/' . $blueprint->tid
+      // Path to module.
+      $module_path = drupal_get_path('module', $_SESSION['oa_export']['module']);
       ;
       $batch = array(
         'title' => t('Blueprint Module Export'),
@@ -133,14 +131,6 @@ function _oa_export_batch_export_blueprint($blueprint, $space, &$context) {
     $context['results']['total'] = (!empty($context['results']['total']) ? $context['results']['total'] : 0) + $context['sandbox']['max'];
   }
 
-  // If we have access to this session variable let's store it in the results, this is more stable.
-  if (isset($_SESSION['oa_export']['module_path'])) {
-    $context['results']['export_path'] = $_SESSION['oa_export']['module_path'];
-  }
-  if (isset($_SESSION['oa_export']['module'])) {
-    $context['results']['module'] = $_SESSION['oa_export']['module'];
-  }
-
   // Store the reference to the space the blueprint is referencing.
   $space_reference = $blueprint->field_oa_clone_space;
 
@@ -205,23 +195,24 @@ function _oa_export_batch_export_dependency($entity, &$context) {
  */
 function oa_export_batch_file_download_finished($success, $results, $operations) {
   if ($success) {
-
     try {
       // Generate a file name that matches our directory.
       $base = basename($_SESSION['oa_export']['directory']);
-      $tmp = file_directory_temp();
-      $_SESSION['oa_export']['file'] = $tmp . DIRECTORY_SEPARATOR . $base . '.tar.gz';
+      $tmp_dir = file_directory_temp();
+      $_SESSION['oa_export']['file'] = $tmp_dir . '/' . $base . '.tar.gz';
 
       // Create a json file to add to our export directory that contains the blueprint.
-      $file = oa_export_create_json_export('entities', $results['export'], $_SESSION['oa_export']['directory']);
-
-      if ($file) {
+      if (!oa_export_create_json_export('entities', $results['export'], $_SESSION['oa_export']['directory'])) {
+        drupal_set_message(t('There was an error creating the export file.'), 'error');
+        oa_export_cleanup(isset($clean_dir) ? $clean_dir : NULL, OA_EXPORT_REDIRECT);
+      }
+      else {
         // Build a compressed file from our blueprint.
         $new_tar = new Archive_Tar($_SESSION['oa_export']['file']);
 
         // We call this directly so we can modify the directory structure for our
-        // tar file. This will remove "/tmp" from the tar.
-        $new_tar->createModify(array($_SESSION['oa_export']['directory']), '', file_directory_temp());
+        // tar file. This will remove the base directory from the tar.
+        $new_tar->createModify(array($_SESSION['oa_export']['directory']), '', $tmp_dir);
 
         // Get the public file directory.
         $public = variable_get('file_public_path', conf_path() . '/files');
@@ -231,7 +222,8 @@ function oa_export_batch_file_download_finished($success, $results, $operations)
           $_SESSION['oa_export']['download_path'] = $copy;
         }
         else {
-          throw new Exception(t('There was a problem copying the export to !public', array('!public' => $public)));
+          drupal_set_message(t('There was a problem copying the export to !public', array('!public' => $public), 'error'));
+          oa_export_cleanup($_SESSION['oa_export']['directory'], OA_EXPORT_REDIRECT);
         }
 
         // Display a message telling the user the export is done.
@@ -240,34 +232,64 @@ function oa_export_batch_file_download_finished($success, $results, $operations)
           // Messages should already be formatted correctly with t().
           drupal_set_message($message, 'warning');
         }
-      }
-      else {
-        drupal_set_message(t('There was an error creating the export file.'), 'error');
+        if (isset($_SESSION['oa_export']['module'])) {
+          // Just remove the oa_export directory. Doesn't matter if this is a new or existing module. We should have
+          // an archive now so we don't need it.
+          oa_export_cleanup($_SESSION['oa_export']['directory'], OA_EXPORT_REDIRECT);
+        }
       }
     }
     catch (Exception $e) {
       drupal_set_message(t('Error: %message', array('%message' => $e->getMessage())));
+      // If this is a new module it removes the module other wise just removes the oa_export directory, clears session
+      // storage and redirects the user.
+      oa_export_cleanup($_SESSION['oa_export']['directory'], OA_EXPORT_REDIRECT);
     }
   }
   else {
-    throw new Exception(t('The batch export was unsuccessful'));
+    drupal_set_message(t('The batch export was unsuccessful'), 'error');
+    // If this is a new module it removes the module other wise just removes the oa_export directory, clears session
+    // storage and redirects the user.
+    oa_export_cleanup($_SESSION['oa_export']['directory'], OA_EXPORT_REDIRECT);
   }
 }
 
 function oa_export_batch_module_export_finished($success, $results, $operations) {
+  $module_path = drupal_get_path('module', $_SESSION['oa_export']['module']);
+  if ($_SESSION['oa_export']['type'] == 'new') {
+    $export_path = $module_path;
+  }
+  else if ($_SESSION['oa_export']['type'] == 'existing') {
+    $export_path = $module_path . '/' . OA_EXPORT_DIR;
+  }
   if ($success) {
-    // See if we can get the module path this way at this point.
-    // @todo: We can, so maybe store less variables in session?
-    $module_path = drupal_get_path('module', $results['module']);
-    if (isset($results['export_path'])) {
-      // Create a json file to add to the oa_export directory in our module.
-      $file = oa_export_create_json_export('entities', $results['export'], $results['export_path'] . '/oa_export');
+    // Create a json file to add to the oa_export directory in our module.
+    $file = oa_export_create_json_export('entities', $results['export'], $module_path . '/' . OA_EXPORT_DIR);
+    // Make sure the file in place and give the user a message accordingly. If the file was successfully written
+    // then we know the module was created as well.
+    if ($file) {
+      // Let the user know the module was created.
+      drupal_set_message(
+        t('The @module module was created at @location.', array(
+          '@module' => $_SESSION['oa_export']['module'],
+          '@location' => $module_path)
+        ), 'status'
+      );
+      // Give them a brief instructions on what they can do now.
+      $message = 'If you exported the blueprint as a new module then just enable the module on the system you want to import the blueprint to. ';
+      $message .= 'If you exported the blueprint to an existing module, update the existing module on the system you are running the import and run a database update.';
+      drupal_set_message(t($message), 'warning');
+      // Clean up just the session variables.
+      oa_export_cleanup();
+    }
+    else {
+      drupal_set_message(t('Unable to create the file for the entity export!'), 'error');
+      oa_export_cleanup($export_path, OA_EXPORT_REDIRECT);
     }
   }
   else {
-    drupal_set_message(t('The batch finished but something went wrong. Try again or contact your system administrator.'));
-    $dir = ($_SESSION['oa_export']['type'] == 'new') ? $_SESSION['oa_export']['module_path'] ? ($_SESSION['oa_export']['type'] == 'existing') : $_SESSION['oa_export']['module_path'] . '/oa_export' : NULL;
-    oa_export_cleanup($dir, $_SESSION['oa_export']['redirect']);
+    drupal_set_message(t('The batch finished but something went wrong. Try again or contact your system administrator.'), 'error');
+    oa_export_cleanup($export_path, OA_EXPORT_REDIRECT);
   }
 }
 
@@ -292,7 +314,7 @@ function oa_export_batch_file_download_finished_redirect() {
   // Remove the temporary tar file.
   unlink($_SESSION['oa_export']['file']);
 
-  // Clean up.
+  // Clear the session variables we stored.
   oa_export_cleanup();
 
   return $output;

--- a/oa_export.batch.import.inc
+++ b/oa_export.batch.import.inc
@@ -6,10 +6,13 @@ require_once 'oa_export.extras.import.inc';
 /**
  * Prepare the import and create a batch process.
  *
- * @param object $file
+ * @param object $data
  *   The file that contains the export data.
+ * @param string $import_type
+ *   Defaults to 'file' but could also be 'module'. This will allow to define different types of exports when
+ *   triggering an import.
  */
-function oa_export_batch_import($file) {
+function oa_export_batch_import($data, $import_type = 'file') {
 
   $batch = array(
     'title' => t('Importing Blueprint'),
@@ -18,8 +21,20 @@ function oa_export_batch_import($file) {
     'file' => drupal_get_path('module', 'oa_export') . '/oa_export.batch.import.inc',
   );
 
-  // Import the space first.
-  oa_export_batch_import_operations($batch, $file);
+  switch ($import_type) {
+
+    case 'file':
+      // Define batch operations.
+      oa_export_batch_import_download_operations($batch, $data);
+      break;
+
+    case 'module':
+      oa_export_batch_import_export_operations($batch, $data);
+      break;
+
+    default:
+      break;
+  }
 
   // Define the batch. The batch is automatically processed since it is
   // triggered by a form submission.
@@ -34,10 +49,34 @@ function oa_export_batch_import($file) {
  * @param object $file
  *   The file that contains the export data.
  */
-function oa_export_batch_import_operations(&$batch, $file) {
+function oa_export_batch_import_download_operations(&$batch, $file) {
 
   // Extracts the archive.
   $batch['operations'][] = array('_oa_export_batch_import_archive', array($file));
+
+  // Imports the entities.
+  $batch['operations'][] = array('_oa_export_batch_import_entities', array());
+
+  // Imports menus. @todo: Fix this...
+//  $batch['operations'][] = array('_oa_export_batch_import_menus', array());
+
+  // Imports group metadata such as roles and permissions. @todo: Fix this...
+//  $batch['operations'][] = array('_oa_export_batch_import_metadata', array());
+
+}
+
+/**
+ * Defines batch operations for the batch.
+ *
+ * @param array $batch
+ *   The current batch.
+ * @param object $data
+ *   The file that contains the export data.
+ */
+function oa_export_batch_import_export_operations(&$batch, $data) {
+
+  // Extracts the archive.
+  $batch['operations'][] = array('_oa_export_batch_import_data', array($data));
 
   // Imports the entities.
   $batch['operations'][] = array('_oa_export_batch_import_entities', array());

--- a/oa_export.batch.import.inc
+++ b/oa_export.batch.import.inc
@@ -152,6 +152,41 @@ function _oa_export_batch_import_archive($file, &$context) {
 }
 
 /**
+ * Extract the file being imported and store the entities in the batch context.
+ *
+ * @param object $file
+ *   The file that contains the export data.
+ * @param array $context
+ *   Passed around between batch operations.
+ * @throws Exception
+ *
+ * @see update_manager_archive_extract().
+ */
+function _oa_export_batch_import_data($data, &$context) {
+
+  if (empty($context['sandbox']['max'])) {
+    $context['sandbox']['progress'] = 0;
+    $context['sandbox']['max'] = 1;
+    $context['results']['total'] = (!empty($context['results']['total']) ? $context['results']['total'] : 0) + $context['sandbox']['max'];
+  }
+
+  // Get the actual path to our json file that contains our entities.
+//  $real_path = realpath($extraction_location . '/entities.json');
+  $module_path = drupal_get_path('module', $name) . '/entities.json';
+
+  // Store the entities.
+  $context['results']['entities'] = oa_export_import_decode_data($module_path);
+  // Will store a map for new entity ids.
+  $context['results']['map'] = array();
+
+  // Bump the progress indicator.
+  $context['sandbox']['progress']++;
+
+  // We are finished un-archiving the entities.
+  $context['finished'] = $context['sandbox']['progress'] / $context['sandbox']['max'];
+}
+
+/**
  * Imports the entities.
  *
  * @param array $context

--- a/oa_export.batch.import.inc
+++ b/oa_export.batch.import.inc
@@ -22,14 +22,13 @@ function oa_export_batch_import($data, $import_type = 'file') {
   );
 
   switch ($import_type) {
-
     case 'file':
       // Define batch operations.
-      oa_export_batch_import_download_operations($batch, $data);
+      oa_export_batch_file_download_operations($batch, $data);
       break;
 
     case 'module':
-      oa_export_batch_import_export_operations($batch, $data);
+      oa_export_batch_module_import_operations($batch, $data);
       break;
 
     default:
@@ -49,20 +48,12 @@ function oa_export_batch_import($data, $import_type = 'file') {
  * @param object $file
  *   The file that contains the export data.
  */
-function oa_export_batch_import_download_operations(&$batch, $file) {
+function oa_export_batch_file_download_operations(&$batch, $file) {
 
   // Extracts the archive.
   $batch['operations'][] = array('_oa_export_batch_import_archive', array($file));
 
-  // Imports the entities.
-  $batch['operations'][] = array('_oa_export_batch_import_entities', array());
-
-  // Imports menus. @todo: Fix this...
-//  $batch['operations'][] = array('_oa_export_batch_import_menus', array());
-
-  // Imports group metadata such as roles and permissions. @todo: Fix this...
-//  $batch['operations'][] = array('_oa_export_batch_import_metadata', array());
-
+  oa_export_batch_combined_operations($batch);
 }
 
 /**
@@ -71,22 +62,24 @@ function oa_export_batch_import_download_operations(&$batch, $file) {
  * @param array $batch
  *   The current batch.
  * @param object $data
- *   The file that contains the export data.
+ *   The export data.
  */
-function oa_export_batch_import_export_operations(&$batch, $data) {
+function oa_export_batch_module_import_operations(&$batch, $path) {
 
   // Extracts the archive.
-  $batch['operations'][] = array('_oa_export_batch_import_data', array($data));
+  $batch['operations'][] = array('_oa_export_batch_import_module_data', array($path));
 
+  oa_export_batch_combined_operations($batch);
+}
+
+function oa_export_batch_combined_operations(&$batch) {
   // Imports the entities.
   $batch['operations'][] = array('_oa_export_batch_import_entities', array());
-
   // Imports menus. @todo: Fix this...
 //  $batch['operations'][] = array('_oa_export_batch_import_menus', array());
 
   // Imports group metadata such as roles and permissions. @todo: Fix this...
 //  $batch['operations'][] = array('_oa_export_batch_import_metadata', array());
-
 }
 
 /**
@@ -154,15 +147,15 @@ function _oa_export_batch_import_archive($file, &$context) {
 /**
  * Extract the file being imported and store the entities in the batch context.
  *
- * @param object $file
- *   The file that contains the export data.
+ * @param string $path
+ *   The realpath to the oa_export directory in the module.
  * @param array $context
  *   Passed around between batch operations.
  * @throws Exception
  *
  * @see update_manager_archive_extract().
  */
-function _oa_export_batch_import_data($data, &$context) {
+function _oa_export_batch_import_module_data($path, &$context) {
 
   if (empty($context['sandbox']['max'])) {
     $context['sandbox']['progress'] = 0;
@@ -170,12 +163,11 @@ function _oa_export_batch_import_data($data, &$context) {
     $context['results']['total'] = (!empty($context['results']['total']) ? $context['results']['total'] : 0) + $context['sandbox']['max'];
   }
 
-  // Get the actual path to our json file that contains our entities.
-//  $real_path = realpath($extraction_location . '/entities.json');
-  $module_path = drupal_get_path('module', $name) . '/entities.json';
+  // This is where the import looks for files.
+  $_SESSION['oa_export']['extract_location'] = $path;
 
-  // Store the entities.
-  $context['results']['entities'] = oa_export_import_decode_data($module_path);
+  // Decode the json file and store the entities for the batch.
+  $context['results']['entities'] = oa_export_import_decode_data($path . '/oa_export/entities.json');
   // Will store a map for new entity ids.
   $context['results']['map'] = array();
 

--- a/oa_export.entity.import.inc
+++ b/oa_export.entity.import.inc
@@ -201,7 +201,7 @@ function oa_export_oa_import_entity_comment(&$entity, $key, &$imports, &$map) {
 function oa_export_oa_import_entity_file(&$entity, $key, &$imports, &$map) {
 
   // The files that were exported are located here.
-  $file_location = $_SESSION['oa_export']['extract_location'] . '/files';
+  $file_location = $_SESSION['oa_export']['extract_location'] . '/' . OA_EXPORT_FILES;
 
   // Make sure our file entity is an array.
   $file = is_object($entity) ? (array) $entity : $entity;
@@ -215,8 +215,7 @@ function oa_export_oa_import_entity_file(&$entity, $key, &$imports, &$map) {
   // Find the actual file we need to import.
   $file_contents = file_get_contents(realpath($file_location.DIRECTORY_SEPARATOR.$filename));
 
-  // Save the file by the same name to its new location. This calls file_save()
-  // for us.
+  // Save the file by the same name to its new location. This calls file_save() for us.
   if ($new_file = file_save_data($file_contents, $destination . $filename)) { // FILE_EXISTS_REPLACE
     // Convert the file back to an object after merging the old file with the
     // new file. This is necessary as the fields that exist on the old file are

--- a/oa_export.file.inc
+++ b/oa_export.file.inc
@@ -70,7 +70,7 @@ function oa_export_create_temp_export_directory($name, $location) {
 function oa_export_create_directories($path) {
   $created = @drupal_mkdir($path, 0755, TRUE);
   if ($created) {
-    return $created;
+    return $path;
   }
   else {
     drupal_set_message(t('The path @path could not be created.', array('@path' => $path)));

--- a/oa_export.file.inc
+++ b/oa_export.file.inc
@@ -35,13 +35,23 @@ function oa_export_create_json_export($name, $export, $location) {
  *
  * @param string $name
  *  The name of the blueprint.
+ * @param string $location
+ *   Where the temporary directory will be created.
+ * @param bool $is_module
+ *   Whether this is a module or just a file download.
+ *
  * @return bool|string
  */
-function oa_export_create_temp_export_directory($name) {
+function oa_export_create_temp_export_directory($name, $location, $is_module = FALSE) {
   // Format the name of the blueprint for the filename.
   $name = str_replace(' ', '_', strtolower($name));
   // The name of the directory we are storing the export.
-  $dir_name = sys_get_temp_dir() . '/' . 'oa_export_' . $name . '_' . REQUEST_TIME;
+  if ($is_module) {
+    $dir_name = $location . '/' . $name;
+  }
+  else {
+    $dir_name = $location . '/' . 'oa_export__' . $name . '__' . REQUEST_TIME;
+  }
   // Create our temporary directory.
   $created = @mkdir($dir_name, 0755, TRUE);
   if ($created) {

--- a/oa_export.file.inc
+++ b/oa_export.file.inc
@@ -37,7 +37,7 @@ function oa_export_create_json_export($name, $export, $location) {
  *  The name of the blueprint.
  * @return bool|string
  */
-function oa_export_create_temp_directory($name) {
+function oa_export_create_temp_export_directory($name) {
   // Format the name of the blueprint for the filename.
   $name = str_replace(' ', '_', strtolower($name));
   // The name of the directory we are storing the export.
@@ -50,50 +50,44 @@ function oa_export_create_temp_directory($name) {
   }
   else {
     // Something happened and the directory couldn't be created.
-    // @todo: Handle this as an exception.
+    drupal_set_message(t('The @dir directory could not be created.', array('@dir' => $dir_name)), 'error');
     return FALSE;
   }
 
 }
 
 /**
- * Helper function to create subdirectories.
+ * Helper function to create directories.
  *
- * @param string $parent
- *  The full path to the parent directory.
- * @param string $child
- *  The name of the sub directory you want to create.
+ * @param string $path
+ *  The full path to the directory or directories you want to create.
  * @return bool|string
  */
-function oa_export_create_sub_directory($parent, $child) {
-  // The sub directory path.
-  $sub_dir = $parent . '/' . $child;
-  // Create our child directory.
-  $created = @mkdir($sub_dir, 0755, TRUE);
+function oa_export_create_directories($path) {
+  $created = @mkdir($path, 0755, TRUE);
   if ($created) {
-    return $sub_dir;
+    return $created;
   }
   else {
-    // Something happened and the directory couldn't be created.
-    // @todo: Handle this as an exception.
+    drupal_set_message(t('The path @path could not be created.', array('@path' => $path)));
     return FALSE;
   }
 
 }
 
 /**
- * Removes the temporary directory we created at the beginning of the export.
+ * Removes a directory recursively along with any files it may contain that was created during the export.
  *
  * @param string $dir
  *   The path to the directory.
  */
-function oa_export_remove_temp_directory($dir) {
+function oa_export_remove_directory($dir) {
   if (is_dir($dir)) {
     $objects = scandir($dir);
     foreach ($objects as $object) {
       if ($object != "." && $object != "..") {
         if (filetype($dir."/".$object) == "dir") {
-          oa_export_remove_temp_directory($dir."/".$object);
+          oa_export_remove_directory($dir."/".$object);
         }
         else {
           unlink($dir."/".$object);

--- a/oa_export.file.inc
+++ b/oa_export.file.inc
@@ -42,18 +42,12 @@ function oa_export_create_json_export($name, $export, $location) {
  *
  * @return bool|string
  */
-function oa_export_create_temp_export_directory($name, $location, $is_module = FALSE) {
+function oa_export_create_temp_export_directory($name, $location) {
   // Format the name of the blueprint for the filename.
   $name = str_replace(' ', '_', strtolower($name));
-  // The name of the directory we are storing the export.
-  if ($is_module) {
-    $dir_name = $location . '/' . $name;
-  }
-  else {
-    $dir_name = $location . '/' . 'oa_export__' . $name . '__' . REQUEST_TIME;
-  }
+  $dir_name = $location . '/' . 'oa_export__' . $name . '__' . REQUEST_TIME;
   // Create our temporary directory.
-  $created = @mkdir($dir_name, 0755, TRUE);
+  $created = @drupal_mkdir($dir_name, 0755, TRUE);
   if ($created) {
     // The name of the directory we will be placing data in for export.
     return $dir_name;
@@ -74,7 +68,7 @@ function oa_export_create_temp_export_directory($name, $location, $is_module = F
  * @return bool|string
  */
 function oa_export_create_directories($path) {
-  $created = @mkdir($path, 0755, TRUE);
+  $created = @drupal_mkdir($path, 0755, TRUE);
   if ($created) {
     return $created;
   }
@@ -105,6 +99,6 @@ function oa_export_remove_directory($dir) {
       }
     }
     reset($objects);
-    @rmdir($dir);
+    @drupal_rmdir($dir);
   }
 }

--- a/oa_export.info
+++ b/oa_export.info
@@ -1,4 +1,4 @@
 name = Open Atrium Export
-description = Allows exporting/importing of a cloned space.
+description = Allows exporting/importing of a blueprint.
 core = 7.x
 package = Open Atrium

--- a/oa_export.module
+++ b/oa_export.module
@@ -8,6 +8,12 @@ require_once('oa_export.file.inc');
 require_once('oa_export.formats.inc');
 require_once('oa_export.fields.export.inc');
 
+define('OA_EXPORT_DEFAULT_MODULE_PATH', 'sites/all/modules');
+define('BLUEPRINT_SPACE', 'field_oa_clone_space');
+define('OA_EXPORT_FILES', 'files');
+define('OA_EXPORT_DIR', 'oa_export');
+define('OA_EXPORT_REDIRECT', 'admin/structure/taxonomy/space_type');
+
 /**
  * Implements hook_menu().
  */
@@ -87,7 +93,7 @@ function oa_export_preprocess_blueprint_download_page(&$variables) {
   // Path to download files, if needed.
   $variables['download_path'] = $_SESSION['oa_export']['download_path'];
   // Path to send user back to.
-  $variables['download_redirect'] = $_SESSION['oa_export']['redirect'];
+  $variables['download_redirect'] = OA_EXPORT_REDIRECT;
 }
 
 /**

--- a/oa_export.module
+++ b/oa_export.module
@@ -1,6 +1,7 @@
 <?php
 
 require_once('oa_export.batch.export.inc');
+require_once('oa_export.module.export.inc');
 require_once('oa_export.form.import.inc');
 require_once('formats/json.inc');
 require_once('oa_export.file.inc');
@@ -12,16 +13,25 @@ require_once('oa_export.fields.export.inc');
  */
 function oa_export_menu() {
   return array(
-    'blueprint/export/%taxonomy_term' => array(
-      'title' => t('Blueprint Export'),
+    'blueprint/download/%taxonomy_term' => array(
+      'title' => 'Blueprint Download',
       'access callback' => 'user_access',
-      'access arguments' => array('export blueprint'),
+      'access arguments' => array('download blueprint'),
       'page callback' => 'oa_export_batch_export',
       'page arguments' => array(2),
       'type' => MENU_CALLBACK,
     ),
+    'blueprint/export/%taxonomy_term' => array(
+      'title' => 'Blueprint Export',
+      'description' => 'Exports you blueprint to a module.',
+      'access callback' => 'user_access',
+      'access arguments' => array('export blueprint'),
+      'page callback' => 'drupal_get_form',
+      'page arguments' => array('oa_export_generate_module_form', 2),
+      'type' => MENU_CALLBACK,
+    ),
     'blueprint/import' => array(
-      'title' => t('Blueprint Import'),
+      'title' => 'Blueprint Import',
       'access callback' => 'user_access',
       'access arguments' => array('import blueprint'),
       'page callback' => 'drupal_get_form',
@@ -29,10 +39,10 @@ function oa_export_menu() {
       'type' => MENU_LOCAL_ACTION,
     ),
     'oa_export/download' => array(
-      'title' => t('Blueprint Download'),
+      'title' => 'Blueprint Download',
       'access callback' => 'user_access',
       'access arguments' => array('export blueprint'),
-      'page callback' => 'oa_export_batch_export_finished_redirect',
+      'page callback' => 'oa_export_batch_export_download_finished_redirect',
     ),
   );
 }

--- a/oa_export.module
+++ b/oa_export.module
@@ -123,7 +123,8 @@ function oa_export_preprocess_table(&$vars) {
       // Add the download link to the last element in the data array.
       $last_key = array_keys($row['data']);
       $end = end($last_key);
-      $row['data'][$end] .= ' ' . l(t('download'), 'blueprint/export/' . $tid);
+      $row['data'][$end] .= ' ' . l(t('download'), 'blueprint/download/' . $tid);
+      $row['data'][$end] .= ' ' . l(t('export'), 'blueprint/export/' . $tid);
     }
   }
 }

--- a/oa_export.module
+++ b/oa_export.module
@@ -52,9 +52,13 @@ function oa_export_menu() {
  */
 function oa_export_permission() {
   return array(
+    'download blueprint' => array(
+      'title' => t('Blueprint Download'),
+      'description' => t('This role will be allowed to download blueprints to an archived file.'),
+    ),
     'export blueprint' => array(
       'title' => t('Blueprint Export'),
-      'description' => t('This role will be allowed to export blueprints.'),
+      'description' => t('This role will be allowed to export a blueprints to a modules.'),
     ),
     'import blueprint' => array(
       'title' => t('Blueprint Import'),

--- a/oa_export.module
+++ b/oa_export.module
@@ -225,3 +225,26 @@ function oa_export_oa_import_remove_entity_alter($entities) {
     }
   }
 }
+
+/**
+ * Removes a directory recusively and if provided will direct the user to a new destination.
+ *
+ * @param string $directory
+ *   The full path the directory to remove.
+ * @param string $goto
+ *   A relative path to send the user to.
+ */
+function oa_export_cleanup($directory = NULL, $goto = NULL) {
+
+  // Get rid of our session variables.
+  unset($_SESSION['oa_export']);
+
+  if (isset($directory)) {
+    // Remove the directory and all its contents.
+    oa_export_remove_directory($directory);
+  }
+  if (isset($goto)) {
+    // Send the user somewhere else.
+    drupal_goto($goto);
+  }
+}

--- a/oa_export.module
+++ b/oa_export.module
@@ -42,7 +42,7 @@ function oa_export_menu() {
       'title' => 'Blueprint Download',
       'access callback' => 'user_access',
       'access arguments' => array('export blueprint'),
-      'page callback' => 'oa_export_batch_export_download_finished_redirect',
+      'page callback' => 'oa_export_batch_file_download_finished_redirect',
     ),
   );
 }

--- a/oa_export.module.export.inc
+++ b/oa_export.module.export.inc
@@ -13,6 +13,8 @@ require_once('oa_export.module.module.inc');
  *
  * @param array $form
  *   Empty form array.
+ * @param $form_state
+ *   A keyed array containing the current state of the form.
  * @param object $blueprint
  *   The fully loaded blueprint entity.
  *
@@ -36,10 +38,11 @@ function oa_export_generate_module_form($form, &$form_state, $blueprint) {
     '#ajax' => array(
       'callback' => 'oa_export_define_module_callback',
       'wrapper' => 'generate-module-form',
-      'methos' => 'replace',
+      'method' => 'replace',
       'effect' => 'fade',
     ),
   );
+
   $form['generate_module_form'] = array(
     '#title' => '',
     '#prefix' => '<div id="generate-module-form">',
@@ -47,19 +50,45 @@ function oa_export_generate_module_form($form, &$form_state, $blueprint) {
     '#type' => 'fieldset',
   );
 
+  $form['actions']['process'] = array(
+    '#type' => 'submit',
+    '#value' => t('Generate Module'),
+    '#name' => 'other',
+    '#ajax' => array(
+      'callback' => 'oa_export_create_module_callback',
+      'wrapper' => 'generate-module-form',
+    ),
+  );
+
   if (isset($form_state['values'])) {
     if ($form_state['values']['choose'] == 'new') {
+      $form['actions']['process']['#validate'][] = 'oa_export_generate_new_module_validate';
       oa_export_generate_new_module_form($form, $form_state);
     }
     else if ($form_state['values']['choose'] == 'existing') {
+      $form['actions']['process']['#validate'][] = 'oa_export_generate_existing_module_validate';
       oa_export_generate_existing_module_form($form, $form_state);
     }
   }
   else {
+    $form['actions']['process']['#validate'][] = 'oa_export_generate_new_module_validate';
     oa_export_generate_new_module_form($form, $form_state);
   }
 
   return $form;
+}
+
+function oa_export_create_module_callback($form, &$form_state) {
+  if (form_get_errors()) {
+    $form_state['rebuild'] = TRUE;
+    $commands = array();
+    $commands[] = ajax_command_prepend(NULL, theme('status_messages'));
+    return array('#type' => 'ajax', '#commands' => $commands);
+  }
+  else {
+    $system_message = drupal_get_messages();
+    return t('Thank you for your submission!');
+  }
 }
 
 /**
@@ -88,22 +117,7 @@ function oa_export_define_module_callback($form, $form_state) {
  *   A keyed array containing the current state of the form.
  */
 function oa_export_generate_module_form_validate($form, &$form_state) {
-  // Seems like the best way to determine which form needs what validation.
-  switch ($form_state['triggering_element']['#name']) {
-    case 'choose':
-      break;
 
-    case 'new_module':
-      oa_export_generate_new_module_validate($form, $form_state);
-      break;
-
-    case 'existing_module':
-      oa_export_generate_existing_module_validate($form, $form_state);
-      break;
-
-    default:
-      break;
-  }
 }
 
 /**
@@ -164,11 +178,6 @@ function oa_export_generate_new_module_form(&$form, &$form_state) {
     '#type' => 'textfield',
     '#required' => FALSE,
     '#default_value' => isset($form_state['input']['generate_path']) ? $form_state['input']['generate_path'] : '',
-  );
-  $form['generate_module_form']['generate'] = array(
-    '#type' => 'submit',
-    '#value' => t('Generate module'),
-    '#name' => 'new_module',
   );
 }
 
@@ -233,11 +242,15 @@ function oa_export_generate_existing_module_form(&$form, &$form_state) {
     '#default_value' => isset($form_state['input']['generate_path']) ? $form_state['input']['generate_path'] : '',
     '#element_validate' => array('oa_export_existing_module_name_validate'),
   );
-  $form['generate_module_form']['generate'] = array(
-    '#type' => 'submit',
-    '#value' => t('Add export to module'),
-    '#name' => 'existing_module',
-  );
+//  $form['generate_module_form']['generate'] = array(
+//    '#type' => 'submit',
+//    '#value' => t('Add export to module'),
+//    '#name' => 'existing_module',
+//    '#ajax' => array(
+//      'callback' => 'oa_export_create_module_callback',
+//      'wrapper' => 'generate-module-form',
+//    ),
+//  );
 }
 
 /**
@@ -290,7 +303,8 @@ function oa_export_generate_new_module_validate($form, &$form_state) {
 
   // We need to create directories and some files. Doing it here so if their creation isn't successful we can throw
   // some errors.
-  if ($files_dir = oa_export_create_directories($module_path . '/' . OA_EXPORT_DIR . '/' . OA_EXPORT_FILES)) {// Start storing data in session.
+  if ($files_dir = oa_export_create_directories($module_path . '/' . OA_EXPORT_DIR . '/' . OA_EXPORT_FILES)) {
+    // Start storing data in session.
     $_SESSION['oa_export'] = array();
     // Store the module name.
     $_SESSION['oa_export']['module'] = $module;
@@ -312,7 +326,7 @@ function oa_export_generate_new_module_validate($form, &$form_state) {
           )
         ));
         // Remove the oa_export directory that was created.
-        oa_export_cleanup($module_path);
+//        oa_export_cleanup($module_path);
       }
     }
   }
@@ -344,7 +358,7 @@ function oa_export_generate_existing_module_validate($form, &$form_state) {
         '@module_path' => $module_path,
       )
     ));
-    oa_export_cleanup(NULL, 'blueprint/export/' . $blueprint);
+//    oa_export_cleanup(NULL, 'blueprint/export/' . $blueprint);
   }
 
   $_SESSION['oa_export'] = array();
@@ -366,7 +380,7 @@ function oa_export_generate_existing_module_validate($form, &$form_state) {
       )
     ));
     // Remove any session variables that were created.
-    oa_export_cleanup($export_dir, 'blueprint/export/' . $blueprint);
+//    oa_export_cleanup($export_dir, 'blueprint/export/' . $blueprint);
   }
   else {
     // Try to create the files directory.
@@ -379,7 +393,7 @@ function oa_export_generate_existing_module_validate($form, &$form_state) {
           '@dir' => $_SESSION['oa_export']['files_directory'],
         )
       ));
-      oa_export_cleanup($export_dir, 'blueprint/export/' . $blueprint);
+//      oa_export_cleanup($export_dir, 'blueprint/export/' . $blueprint);
     }
     else {
       // File types for a module that we need to update.
@@ -387,19 +401,18 @@ function oa_export_generate_existing_module_validate($form, &$form_state) {
       foreach ($file_types as $extension) {
         $success = oa_export_update_existing_module($module_path, $extension, $form_state);
         if (!$success) {
-          // Remove the oa_export directory that was created.
-          // Set a form error.
           form_set_error(NULL, t("Couldn't update the contents of the @module_name.@extension file at the path @module_path. Please check your permissions.", array(
               '@extension' => $extension,
               '@module_name' => $_SESSION['oa_export']['module'],
               '@module_path' => $module_path,
             )
           ));
-          oa_export_cleanup($module_path . '/' . OA_EXPORT_DIR);
+//          oa_export_cleanup($module_path . '/' . OA_EXPORT_DIR);
         }
       }
     }
   }
+  form_set_error(NULL, t('Some error'));
 }
 
 /**
@@ -425,14 +438,14 @@ function oa_export_update_existing_module($module_path, $extension, $form_state)
 
     case 'module':
       // Make sure the file exists. Some modules have an install file but it's not required.
-      if (file_exists($module_path . '/' . $form_state['values']['machine_name'] . '.module')) {
+      if (file_exists($module_path . '/' . $form_state['values']['generate_path'] . '.module')) {
         $success = oa_export_update_existing_module_file($module_path, $form_state);
       }
       break;
 
     case 'install':
       // Make sure the file exists. Some modules have an install file but it's not required.
-      if (file_exists($module_path . '/' . $form_state['values']['machine_name'] . '.install')) {
+      if (file_exists($module_path . '/' . $form_state['values']['generate_path'] . '.install')) {
         $success = oa_export_update_existing_install_file($module_path, $form_state);
       }
       else {
@@ -455,18 +468,31 @@ function oa_export_update_existing_module($module_path, $extension, $form_state)
  *   A keyed array containing the current state of the form.
  */
 function oa_export_generate_module_form_submit($form, &$form_state) {
-  // Load the full blueprint.
-  $blueprint = taxonomy_term_load($form_state['values']['blueprint']);
 
-  // Export the blueprint via batch.
-  oa_export_batch_export($blueprint, 'module');
+  if (form_get_errors()) {
+    $form_state['rebuild'] = TRUE;
+    return $form;
+  }
+  $errors = form_get_errors();
 
-  // Redirect the user to the current path.
-  batch_process(current_path());
+  if (!form_get_errors()) {
+    // Load the full blueprint.
+    $blueprint = taxonomy_term_load($form_state['values']['blueprint']);
+
+    // Export the blueprint via batch.
+    oa_export_batch_export($blueprint, 'module');
+
+    // Redirect the user to the current path.
+    batch_process(current_path());
+  }
+  else {
+    $element = $form['generate_module_form'];
+    return $element;
+  }
 }
 
 /**
- * Helper function to create a module file.
+ * Helper function to create a new file for a module.
  *
  * @param string $module_path
  *   The absolute path to the modules location.
@@ -507,7 +533,8 @@ function oa_export_search_file($file, $pattern) {
       while (($line = fgets($h)) !== false) {
         preg_match($pattern, $line, $matches);
         if ($matches) {
-          $results[] = $matches[1];
+          $results[] = $matches[0];
+          break;
         }
         else {
           continue;

--- a/oa_export.module.export.inc
+++ b/oa_export.module.export.inc
@@ -1,10 +1,12 @@
 <?php
 /**
- * @file
- * Exports the blueprint to a module. When the module is enabled the blueprint will be imported.
+ * @file oa_export.module.export.inc
+ * Provides a way to export a blueprint via a new or existing module.
  */
 
-define('OA_EXPORT_DEFAULT_MODULE_PATH', 'sites/all/modules');
+require_once('oa_export.module.install.inc');
+require_once('oa_export.module.info.inc');
+require_once('oa_export.module.module.inc');
 
 /**
  * Form used to export a blueprint to a module.
@@ -45,11 +47,16 @@ function oa_export_generate_module_form($form, &$form_state, $blueprint) {
     '#type' => 'fieldset',
   );
 
-  if ($form['module']['choose']['#default_value'] == 'new') {
-    oa_export_generate_new_module_form($form, $form_state);
+  if (isset($form_state['values'])) {
+    if ($form_state['values']['choose'] == 'new') {
+      oa_export_generate_new_module_form($form, $form_state);
+    }
+    else if ($form_state['values']['choose'] == 'existing') {
+      oa_export_generate_existing_module_form($form, $form_state);
+    }
   }
-  else if ($form['module']['choose']['#default_value'] == 'existing') {
-    oa_export_generate_existing_module_form($form, $form_state);
+  else {
+    oa_export_generate_new_module_form($form, $form_state);
   }
 
   return $form;
@@ -68,6 +75,7 @@ function oa_export_generate_module_form($form, &$form_state, $blueprint) {
  *   The form used to generate a module.
  */
 function oa_export_define_module_callback($form, $form_state) {
+  // For returned for ajax callback.
   return $form['generate_module_form'];
 }
 
@@ -107,7 +115,6 @@ function oa_export_generate_module_form_validate($form, &$form_state) {
  *   A keyed array containing the current state of the form.
  */
 function oa_export_generate_new_module_form(&$form, &$form_state) {
-  $dcc = DRUPAL_CORE_COMPATIBILITY;
   $form['generate_module_form']['name'] = array(
     '#title' => t('Name'),
     '#description' => t('Example: Project Blueprint') . ' (' . t('Do not begin name with numbers.') . ')',
@@ -137,7 +144,7 @@ function oa_export_generate_new_module_form(&$form, &$form_state) {
   );
   $form['generate_module_form']['version'] = array(
     '#title' => t('Version'),
-    '#description' => t('Examples: @examples', array('@examples' => $dcc . '-1.0, ' . $dcc . '-1.0-beta1')),
+    '#description' => t('Examples: @examples', array('@examples' => DRUPAL_CORE_COMPATIBILITY . '-1.0, ' . DRUPAL_CORE_COMPATIBILITY . '-1.0-beta1')),
     '#type' => 'textfield',
     '#required' => FALSE,
     '#default_value' => isset($form_state['input']['version']) ? $form_state['input']['version'] : '',
@@ -157,7 +164,6 @@ function oa_export_generate_new_module_form(&$form, &$form_state) {
     '#type' => 'textfield',
     '#required' => FALSE,
     '#default_value' => isset($form_state['input']['generate_path']) ? $form_state['input']['generate_path'] : '',
-    '#element_validate' => array('oa_export_module_generate_path_validate'),
   );
   $form['generate_module_form']['generate'] = array(
     '#type' => 'submit',
@@ -167,7 +173,7 @@ function oa_export_generate_new_module_form(&$form, &$form_state) {
 }
 
 /**
- * Handles validation on the 'machine_name' form element.
+ * Handles validation on the 'machine_name' form element. Confirms the module name is unique.
  *
  * @param $element
  *   The form element being validated.
@@ -210,25 +216,6 @@ function oa_export_module_version_validate($element, &$form_state, $form) {
 }
 
 /**
- * Handles validation on the 'generate_path' form element.
- *
- * @param $element
- *   The form element being validated.
- * @param $form_state
- *   A keyed array containing the current state of the form.
- * @param $form
- *   An associative array containing the structure of the form.
- */
-function oa_export_module_generate_path_validate($element, &$form_state, $form) {
-  if (!empty($element['#value'])) {
-    $generate_path = DRUPAL_ROOT . '/' . $element['#value'];
-    if (!is_dir($generate_path)) {
-      form_error($element, t('Invalid path, make sure @path is a valid path and you have access to it.', array('@path' => $generate_path)));
-    }
-  }
-}
-
-/**
  * Generates the form for adding the export to an existing module. This one is much simpler. We just need
  * the name of the module we will be adding the export to.
  *
@@ -264,12 +251,20 @@ function oa_export_generate_existing_module_form(&$form, &$form_state) {
  *   An associative array containing the structure of the form.
  */
 function oa_export_existing_module_name_validate($element, &$form_state, $form) {
-  if (!empty($element['#value']) && !module_exists($element['#value'])) {
-    form_error($element, t(
-      'The @name module does not exist.', array(
-        '@name' => $element['#value'],
-      )
-    ));
+  if (empty($element['#value'])) {
+    form_error($element, t('You must enter the machine_name of an existing module.'));
+  }
+  else {
+    // We build the absolute path. The module may be a work in progress and may not be enabled yet so this is the best
+    // way to find it.
+    $module_path = DRUPAL_ROOT . '/' . drupal_get_path('module', $element['#value']);
+    if (!file_exists($module_path)) {
+      form_error($element, t(
+        'The @name module could not be found!.', array(
+          '@name' => $element['#value'],
+        )
+      ));
+    }
   }
 }
 
@@ -282,66 +277,51 @@ function oa_export_existing_module_name_validate($element, &$form_state, $form) 
  *   A keyed array containing the current state of the form.
  */
 function oa_export_generate_new_module_validate($form, &$form_state) {
-
-  // We need to validate that we can create a directory based on the form input.
-  $info = array(
-    'name' => $form_state['values']['name'],
-    'machine_name' => $form_state['values']['machine_name'],
-    'description' => $form_state['values']['description'],
-    'package' => $form_state['values']['package'],
-    'core' => DRUPAL_CORE_COMPATIBILITY,
-    'version' => $form_state['values']['version'],
-  );
-
-  // @todo: Try storing the info array in form state storage.
-  $form_state['storage']['module_info'] = $info;
-
+  $module = $form_state['values']['machine_name'];
   // We will be creating a new module in sites/all/modules.
   if (empty($form_state['values']['generate_path'])) {
-    $module_path = DRUPAL_ROOT . '/' . OA_EXPORT_DEFAULT_MODULE_PATH . '/' . $info['machine_name'];
+    $module_path = DRUPAL_ROOT . '/' . OA_EXPORT_DEFAULT_MODULE_PATH . '/' . $module;
   }
   // Either we are creating a new module at a different path or just adding the export to an existing module.
   else {
     // The path to where the module will be written as defined by the user.
-    $generate_path = $form_state['values']['generate_path'];
-    $module_path = DRUPAL_ROOT . '/' . $form_state['values']['generate_path'];
+    $module_path = DRUPAL_ROOT . '/' . $form_state['values']['generate_path'] . '/'. $module;
   }
-
-  $_SESSION['oa_export'] = array();
-  // Store the module path so we have access after the batch runs.
-  // @todo: See if we can get rid of this by trying to call drupal_get_path('module', MODULE_NAME); in the batch finish function.
-  $_SESSION['oa_export']['module_path'] = $module_path;
-  $_SESSION['oa_export']['module'] = $info['machine_name'];
-  $_SESSION['oa_export']['type'] = 'new';
 
   // We need to create directories and some files. Doing it here so if their creation isn't successful we can throw
   // some errors.
-  if (!oa_export_create_directories($module_path . '/oa_export/files')) {
-    form_set_error(NULL, t("Couldn't create the module: @module_name at the path @module_path. Please check your permissions.", array(
-        '@module_name' => $info['machine_name'],
-        '@module_path' => $module_path,
-      )
-    ));
-  }
-  else {
-    // Set the directory for file export.
-    $_SESSION['oa_export']['files_directory'] = $module_path . '/oa_export/files';
+  if ($files_dir = oa_export_create_directories($module_path . '/' . OA_EXPORT_DIR . '/' . OA_EXPORT_FILES)) {// Start storing data in session.
+    $_SESSION['oa_export'] = array();
+    // Store the module name.
+    $_SESSION['oa_export']['module'] = $module;
+    // Lets us know this is a new module, that they aren't adding the export to an existing module.
+    $_SESSION['oa_export']['type'] = 'new';
+    // This is where files will be stored.
+    $_SESSION['oa_export']['files_directory'] = $files_dir;
+
     // File types used to create a basic module.
     $file_types = array('module', 'info', 'install');
     foreach ($file_types as $extension) {
-      $success = oa_export_create_module_file($module_path, $info, $extension);
+      $success = oa_export_create_module_file($module_path, $form_state, $extension);
       if (!$success) {
-        // Remove the oa_export directory that was created.
-        oa_export_cleanup($module_path);
         // Set a form error.
         form_set_error(NULL, t("Couldn't create the @module_name.@extension file at the path @module_path. Please check your permissions.", array(
             '@extension' => $extension,
-            '@module_name' => $info['machine_name'],
+            '@module_name' => $module,
             '@module_path' => $module_path,
           )
         ));
+        // Remove the oa_export directory that was created.
+        oa_export_cleanup($module_path);
       }
     }
+  }
+  else {
+    form_set_error(NULL, t("Couldn't create the module: @module_name at the path @module_path. Please check your permissions.", array(
+        '@module_name' => $module,
+        '@module_path' => $module_path,
+      )
+    ));
   }
 }
 
@@ -354,39 +334,116 @@ function oa_export_generate_new_module_validate($form, &$form_state) {
  *   A keyed array containing the current state of the form.
  */
 function oa_export_generate_existing_module_validate($form, &$form_state) {
-
-  // Get the path to the existing module.
-  $module_path = drupal_get_path('module', $form_state['values']['generate_path']);
-
-  $_SESSION['oa_export'] = array();
-
-  // Store the module path so we have access after the batch runs.
-  // @todo: See if we can get rid of this by trying to call drupal_get_path('module', MODULE_NAME); in the batch finish function.
-  $_SESSION['oa_export']['module_path'] = $module_path;
-  $_SESSION['oa_export']['module'] = $form_state['values']['generate_path'];
-  $_SESSION['oa_export']['type'] = 'existing';
-
-  // Try to create the oa_export directory. Set an error if we are unsuccessful.
-  if (!oa_export_create_directories($module_path . '/oa_export')) {
-    form_set_error(NULL, t("Couldn't create the oa_export directory in @module_name at the path @module_path. Please check your permissions.", array(
-        '@module_name' => $form_state['values']['generate_path'],
+  $module = $form_state['values']['generate_path'];
+  $blueprint = $form_state['values']['blueprint'];
+  // The path to the existing module.
+  $module_path = DRUPAL_ROOT . '/'. drupal_get_path('module', $module);
+  if (empty($module_path)) {
+    form_set_error(NULL, t("Couldn't find that the @module module at @module_path. Does it exist?.", array(
+        '@module' => $module,
         '@module_path' => $module_path,
       )
     ));
+    oa_export_cleanup(NULL, 'blueprint/export/' . $blueprint);
+  }
+
+  $_SESSION['oa_export'] = array();
+  // Store the name of the module so we have access after the batch runs.
+  $_SESSION['oa_export']['module'] = $module;
+  // Lets us know we are adding the export to an existing module.
+  $_SESSION['oa_export']['type'] = 'existing';
+  // This is where files will be stored.
+  $_SESSION['oa_export']['files_directory'] = $module_path . '/' . OA_EXPORT_DIR . '/' . OA_EXPORT_FILES;
+
+  // Try to create the oa_export directory.
+  $export_dir = oa_export_create_directories($module_path . '/' . OA_EXPORT_DIR);
+  // Set an error if we are unsuccessful.
+  if (!$export_dir) {
+    form_set_error(NULL, t("Couldn't create the @dir directory in @module_name at the path @module_path. Please check your permissions.", array(
+        '@dir' => OA_EXPORT_DIR,
+        '@module_name' => $module,
+        '@module_path' => $module_path,
+      )
+    ));
+    // Remove any session variables that were created.
+    oa_export_cleanup($export_dir, 'blueprint/export/' . $blueprint);
   }
   else {
     // Try to create the files directory.
-    if (!oa_export_create_directories($module_path . '/oa_export/files')) {
+    $files_dir = oa_export_create_directories($export_dir . '/' . OA_EXPORT_FILES);
+    if (!$files_dir) {
+      $blueprint = $form_state['values']['blueprint'];
       // Remove the oa_export directory that was created.
-      oa_export_cleanup($module_path . '/oa_export');
-      form_set_error(NULL, t("Couldn't create a files directory in @module_name/oa_export at the path @module_path. Please check your permissions.", array(
-          '@module_name' => $form_state['values']['generate_path'],
-          '@module_path' => $module_path,
+      form_set_error(NULL, t("Couldn't create a files directory in @dir for the module @module_name. Please check your permissions.", array(
+          '@module_name' => $module,
+          '@dir' => $_SESSION['oa_export']['files_directory'],
         )
       ));
+      oa_export_cleanup($export_dir, 'blueprint/export/' . $blueprint);
+    }
+    else {
+      // File types for a module that we need to update.
+      $file_types = array('info', 'install');
+      foreach ($file_types as $extension) {
+        $success = oa_export_update_existing_module($module_path, $extension, $form_state);
+        if (!$success) {
+          // Remove the oa_export directory that was created.
+          // Set a form error.
+          form_set_error(NULL, t("Couldn't update the contents of the @module_name.@extension file at the path @module_path. Please check your permissions.", array(
+              '@extension' => $extension,
+              '@module_name' => $_SESSION['oa_export']['module'],
+              '@module_path' => $module_path,
+            )
+          ));
+          oa_export_cleanup($module_path . '/' . OA_EXPORT_DIR);
+        }
+      }
     }
   }
+}
 
+/**
+ * Update an existing module for the export.
+ *
+ * @param string $module_path
+ *   The absolute path to the modules location.
+ * @param string $extension
+ *   The extension of the file being created, e.g. module, info, install. Without the ".".
+ * @param $form_state
+ *   A keyed array containing the current state of the form.
+ *
+ * @return bool
+ *   Lets us know if the file was updated successfully.
+ */
+function oa_export_update_existing_module($module_path, $extension, $form_state) {
+  $success = FALSE;
+
+  switch ($extension) {
+    case 'info':
+      $success = oa_export_update_existing_info_file($module_path, $form_state);
+      break;
+
+    case 'module':
+      // Make sure the file exists. Some modules have an install file but it's not required.
+      if (file_exists($module_path . '/' . $form_state['values']['machine_name'] . '.module')) {
+        $success = oa_export_update_existing_module_file($module_path, $form_state);
+      }
+      break;
+
+    case 'install':
+      // Make sure the file exists. Some modules have an install file but it's not required.
+      if (file_exists($module_path . '/' . $form_state['values']['machine_name'] . '.install')) {
+        $success = oa_export_update_existing_install_file($module_path, $form_state);
+      }
+      else {
+        $success = oa_export_create_new_install_file($module_path, $form_state);
+      }
+      break;
+
+    default:
+      break;
+  }
+  return $success;
 }
 
 /**
@@ -398,97 +455,77 @@ function oa_export_generate_existing_module_validate($form, &$form_state) {
  *   A keyed array containing the current state of the form.
  */
 function oa_export_generate_module_form_submit($form, &$form_state) {
-  $current_path = current_path();
-  $blueprint_tid = $form_state['values']['blueprint'];
+  // Load the full blueprint.
+  $blueprint = taxonomy_term_load($form_state['values']['blueprint']);
 
-  $blueprint = taxonomy_term_load($blueprint_tid);
+  // Export the blueprint via batch.
   oa_export_batch_export($blueprint, 'module');
+
   // Redirect the user to the current path.
-  batch_process($current_path);
+  batch_process(current_path());
 }
 
 /**
- * Helper function to create the actual MODULE.module file.
+ * Helper function to create a module file.
  *
  * @param string $module_path
- *   The full 'realpath' to where the module resides.
- * @param array $info
- *   Contains values needed to create the module keyed by keys used to create the MODULE.info file.
+ *   The absolute path to the modules location.
+ * @param array $form_state
+ *   A keyed array containing the current state of the form.
  * @param $extension
  *   The extension of the file being created, e.g. module, info, install.
  *
  * @return bool
  *   Whether the file was successfully created or not.
  */
-function oa_export_create_module_file($module_path, $info, $extension) {
-  $function = 'oa_export_file_content_' . $extension;
-  return $function($module_path, $info);
-}
-
-function oa_export_file_content_module($module_path, $info) {
-  $output = "<?php\n/**\n* @file\n* Drupal needs this blank file.\n*/\n";
-
-  if (file_put_contents($module_path . '/' . $info['machine_name'] . '.module', $output, FILE_APPEND) === FALSE) {
-    return FALSE;
-  }
-  else {
-    return TRUE;
-  }
+function oa_export_create_module_file($module_path, $form_state, $extension) {
+  $function = 'oa_export_create_new_' . $extension . '_file';
+  return $function($module_path, $form_state);
 }
 
 /**
- * Helper function to create the actual MODULE.info file.
+ * Helper function to search a file for a pattern.
  *
- * @param string $module_path
- *   The full 'realpath' to where the module resides.
- * @param array $info
- *   Contains values needed to create the module keyed by keys used to create the MODULE.info file.
+ * @param $path
+ *   The absolute path to the file.
+ * @param $pattern
  *
- * @return bool
- *   Whether the file was successfully created or not.
+ * @return array|bool
+ *   Returns the match if one is found, otherwise FALSE.
  */
-function oa_export_file_content_info($module_path, $info) {
-  $keys = array('name', 'description', 'package', 'core', 'version');
-  $output = '';
-  foreach ($keys as $key) {
-    if (!empty($info[$key])) {
-      $output .= "$key = $info[$key]\n";
+function oa_export_search_file($file, $pattern) {
+  try {
+    if (!file_exists($file)) {
+      throw new Exception(t('The file @file could not be found!', array('@file' => $file)));
+    }
+    $h = fopen($file, 'r');
+    if (!$h) {
+      throw new Exception(t('The file @file could not be opened!', array('@file' => $file)));
+    }
+    else {
+      // Iterate
+      while (($line = fgets($h)) !== false) {
+        preg_match($pattern, $line, $matches);
+        if ($matches) {
+          $results[] = $matches[1];
+        }
+        else {
+          continue;
+        }
+      }
+      fclose($h);
+      // If we have found existing update hooks.
+      if (!empty($results)) {
+        // Get the last update version in the file.
+        return $results;
+      }
+      else {
+        return FALSE;
+      }
     }
   }
-  // We only need a dependency on oa_export for now.
-  $output .= "dependencies[] = oa_export";
-
-  if (file_put_contents($module_path . '/' . $info['machine_name'] . '.info', $output, FILE_APPEND|FILE_TEXT) === FALSE) {
-    return FALSE;
-  }
-  else {
-    return TRUE;
-  }
-}
-
-/**
- * Helper function to create the actual MODULE.install file.
- *
- * @param string $module_path
- *   The full 'realpath' to where the module resides.
- * @param array $info
- *   Contains values needed to create the module keyed by keys used to create the MODULE.info file.
- *
- * @return bool
- *   Whether the file was successfully created or not.
- */
-function oa_export_file_content_install($module_path, $info) {
-  $output = '';
-  $output .= "<?php\n/**\n* @file\n* Install, update and uninstall functions.\n*/\n";
-  $output .= "\n";
-  $output .= "function {$info['machine_name']}_install() {\n";
-  $output .= "  // This should be indented. For code.\n";
-  $output .= "}\n";
-
-  if (file_put_contents($module_path . '/' . $info['machine_name'] . '.install', $output, FILE_APPEND) === FALSE) {
-    return FALSE;
-  }
-  else {
-    return TRUE;
+  catch (Exception $e) {
+    $message = $e->getMessage();
+    drupal_set_message(t($message), 'error');
   }
 }

--- a/oa_export.module.export.inc
+++ b/oa_export.module.export.inc
@@ -1,0 +1,494 @@
+<?php
+/**
+ * @file
+ * Exports the blueprint to a module. When the module is enabled the blueprint will be imported.
+ */
+
+define('OA_EXPORT_DEFAULT_MODULE_PATH', 'sites/all/modules');
+
+/**
+ * Form used to export a blueprint to a module.
+ *
+ * @param array $form
+ *   Empty form array.
+ * @param object $blueprint
+ *   The fully loaded blueprint entity.
+ *
+ * @return array $form
+ *   The fully built form used to collect data to generate a module.
+ */
+function oa_export_generate_module_form($form, &$form_state, $blueprint) {
+
+  $form['module']['blueprint'] = array(
+    '#type' => 'hidden',
+    '#value' => $blueprint->tid,
+  );
+  $form['module']['help'] = array(
+    '#markup' => t('Creates a module that will import the blueprint when installed or adds the export to an existing module.'),
+  );
+  $form['module']['choose'] = array(
+    '#title' => t('Choose an option.'),
+    '#type' => 'select',
+    '#options' => array('new' => t('Create a new module'), 'existing' => t('Add to an existing module')),
+    '#default_value' => isset($form_state['input']['choose']) ? $form_state['input']['choose'] : 'new',
+    '#ajax' => array(
+      'callback' => 'oa_export_define_module_callback',
+      'wrapper' => 'generate-module-form',
+      'methos' => 'replace',
+      'effect' => 'fade',
+    ),
+  );
+  $form['generate_module_form'] = array(
+    '#title' => '',
+    '#prefix' => '<div id="generate-module-form">',
+    '#suffix' => '</div>',
+    '#type' => 'fieldset',
+  );
+
+  if ($form['module']['choose']['#default_value'] == 'new') {
+    oa_export_generate_new_module_form($form, $form_state);
+  }
+  else if ($form['module']['choose']['#default_value'] == 'existing') {
+    oa_export_generate_existing_module_form($form, $form_state);
+  }
+
+  return $form;
+}
+
+/**
+ * Ajax callback for choosing the type of module export. The are either creating a new module or they want to add the
+ * export to an existing module.
+ *
+ * @param $form
+ *   An associative array containing the structure of the form.
+ * @param $form_state
+ *   A keyed array containing the current state of the form.
+ *
+ * @return array
+ *   The form used to generate a module.
+ */
+function oa_export_define_module_callback($form, $form_state) {
+  return $form['generate_module_form'];
+}
+
+/**
+ * Handles validation for the 'generate_module' form.
+ *
+ * @param $form
+ *   An associative array containing the structure of the form.
+ * @param $form_state
+ *   A keyed array containing the current state of the form.
+ */
+function oa_export_generate_module_form_validate($form, &$form_state) {
+  // Seems like the best way to determine which form needs what validation.
+  switch ($form_state['triggering_element']['#name']) {
+    case 'choose':
+      break;
+
+    case 'new_module':
+      oa_export_generate_new_module_validate($form, $form_state);
+      break;
+
+    case 'existing_module':
+      oa_export_generate_existing_module_validate($form, $form_state);
+      break;
+
+    default:
+      break;
+  }
+}
+
+/**
+ * Generates the form for creating a new module to add the export to.
+ *
+ * @param $form
+ *   An associative array containing the structure of the form.
+ * @param $form_state
+ *   A keyed array containing the current state of the form.
+ */
+function oa_export_generate_new_module_form(&$form, &$form_state) {
+  $dcc = DRUPAL_CORE_COMPATIBILITY;
+  $form['generate_module_form']['name'] = array(
+    '#title' => t('Name'),
+    '#description' => t('Example: Project Blueprint') . ' (' . t('Do not begin name with numbers.') . ')',
+    '#type' => 'textfield',
+    '#required' => TRUE,
+    '#default_value' => isset($form_state['input']['name']) ? $form_state['input']['name'] : '',
+  );
+  $form['generate_module_form']['machine_name'] = array(
+    '#type' => 'machine_name',
+    '#title' => t('Machine-readable name'),
+    '#description' => t('Example: project_blueprint' .
+      '<br/>' .
+      t('May only contain lowercase letters, numbers and underscores. <strong>Try to avoid conflicts with the names of existing Drupal projects.</strong>')
+    ),
+    '#required' => TRUE,
+    '#default_value' => isset($form_state['input']['machine_name']) ? $form_state['input']['machine_name'] : '',
+    '#machine_name' => array(
+      'exists' => 'oa_export_module_machine_name_validate',
+      'source' => array('generate_module_form', 'name'),
+    ),
+  );
+  $form['generate_module_form']['description'] = array(
+    '#title' => t('Description'),
+    '#description' => t('Provide a short description of what users should expect when they enable your module.'),
+    '#type' => 'textfield',
+    '#default_value' => isset($form_state['input']['description']) ? $form_state['input']['description'] : '',
+  );
+  $form['generate_module_form']['version'] = array(
+    '#title' => t('Version'),
+    '#description' => t('Examples: @examples', array('@examples' => $dcc . '-1.0, ' . $dcc . '-1.0-beta1')),
+    '#type' => 'textfield',
+    '#required' => FALSE,
+    '#default_value' => isset($form_state['input']['version']) ? $form_state['input']['version'] : '',
+    '#element_validate' => array('oa_export_module_version_validate'),
+  );
+  $form['generate_module_form']['package'] = array(
+    '#title' => t('Package'),
+    '#description' => t('The group it will be displayed under in the module list.'),
+    '#type' => 'textfield',
+    '#required' => FALSE,
+    '#default_value' => isset($form_state['input']['package']) ? $form_state['input']['package'] : '',
+  );
+  $form['generate_module_form']['generate_path'] = array(
+    '#title' => t('Path to generate module'),
+    '#description' => t('The relative path where the module will be created.') .
+      t('Leave blank for <strong>@path</strong>.', array('@path' => OA_EXPORT_DEFAULT_MODULE_PATH)),
+    '#type' => 'textfield',
+    '#required' => FALSE,
+    '#default_value' => isset($form_state['input']['generate_path']) ? $form_state['input']['generate_path'] : '',
+    '#element_validate' => array('oa_export_module_generate_path_validate'),
+  );
+  $form['generate_module_form']['generate'] = array(
+    '#type' => 'submit',
+    '#value' => t('Generate module'),
+    '#name' => 'new_module',
+  );
+}
+
+/**
+ * Handles validation on the 'machine_name' form element.
+ *
+ * @param $element
+ *   The form element being validated.
+ * @param $form_state
+ *   A keyed array containing the current state of the form.
+ * @param $form
+ *   An associative array containing the structure of the form.
+ */
+function oa_export_module_machine_name_validate($element, &$form_state, $form) {
+  $modules = system_rebuild_module_data();
+  foreach ($modules as $name => $module) {
+    if ($element === $name) {
+      form_error($element, t(
+        'The machine name @name is already being used by another module. Please choose another.', array(
+          '@name' => $name,
+        )
+      ));
+    }
+  }
+}
+
+/**
+ * Handles validation on the 'version' form element.
+ *
+ * Similar to @see features_export_form_validate_field().
+ *
+ * @param $element
+ *   The form element being validated.
+ * @param $form_state
+ *   A keyed array containing the current state of the form.
+ * @param $form
+ *   An associative array containing the structure of the form.
+ */
+function oa_export_module_version_validate($element, &$form_state, $form) {
+  preg_match('/^(?P<core>\d+\.x)-(?P<major>\d+)\.(?P<patch>\d+)-?(?P<extra>\w+)?$/', $element['#value'], $matches);
+  if (!empty($element['#value']) && !isset($matches['core'], $matches['major'])) {
+    $example = DRUPAL_CORE_COMPATIBILITY . '-1.0';
+    form_error($element, t('Please enter a valid version with core and major version number. Example: @example', array('@example' => $example)));
+  }
+}
+
+/**
+ * Handles validation on the 'generate_path' form element.
+ *
+ * @param $element
+ *   The form element being validated.
+ * @param $form_state
+ *   A keyed array containing the current state of the form.
+ * @param $form
+ *   An associative array containing the structure of the form.
+ */
+function oa_export_module_generate_path_validate($element, &$form_state, $form) {
+  if (!empty($element['#value'])) {
+    $generate_path = DRUPAL_ROOT . '/' . $element['#value'];
+    if (!is_dir($generate_path)) {
+      form_error($element, t('Invalid path, make sure @path is a valid path and you have access to it.', array('@path' => $generate_path)));
+    }
+  }
+}
+
+/**
+ * Generates the form for adding the export to an existing module. This one is much simpler. We just need
+ * the name of the module we will be adding the export to.
+ *
+ * @param $form_state
+ *   A keyed array containing the current state of the form.
+ * @param $form
+ *   An associative array containing the structure of the form.
+ */
+function oa_export_generate_existing_module_form(&$form, &$form_state) {
+  $form['generate_module_form']['generate_path'] = array(
+    '#title' => t('Name of module'),
+    '#description' => t('This should be the <strong>machine_name</strong> of an existing module in your system'),
+    '#type' => 'textfield',
+    '#required' => TRUE,
+    '#default_value' => isset($form_state['input']['generate_path']) ? $form_state['input']['generate_path'] : '',
+    '#element_validate' => array('oa_export_existing_module_name_validate'),
+  );
+  $form['generate_module_form']['generate'] = array(
+    '#type' => 'submit',
+    '#value' => t('Add export to module'),
+    '#name' => 'existing_module',
+  );
+}
+
+/**
+ * Handles validation on the 'generate_path' form element when it is used while exporting to an existing module.
+ *
+ * @param $element
+ *   The form element being validated.
+ * @param $form_state
+ *   A keyed array containing the current state of the form.
+ * @param $form
+ *   An associative array containing the structure of the form.
+ */
+function oa_export_existing_module_name_validate($element, &$form_state, $form) {
+  if (!empty($element['#value']) && !module_exists($element['#value'])) {
+    form_error($element, t(
+      'The @name module does not exist.', array(
+        '@name' => $element['#value'],
+      )
+    ));
+  }
+}
+
+/**
+ * Handles validation on the 'new_module' form.
+ *
+ * @param $form
+ *   An associative array containing the structure of the form.
+ * @param $form_state
+ *   A keyed array containing the current state of the form.
+ */
+function oa_export_generate_new_module_validate($form, &$form_state) {
+
+  // We need to validate that we can create a directory based on the form input.
+  $info = array(
+    'name' => $form_state['values']['name'],
+    'machine_name' => $form_state['values']['machine_name'],
+    'description' => $form_state['values']['description'],
+    'package' => $form_state['values']['package'],
+    'core' => DRUPAL_CORE_COMPATIBILITY,
+    'version' => $form_state['values']['version'],
+  );
+
+  // @todo: Try storing the info array in form state storage.
+  $form_state['storage']['module_info'] = $info;
+
+  // We will be creating a new module in sites/all/modules.
+  if (empty($form_state['values']['generate_path'])) {
+    $module_path = DRUPAL_ROOT . '/' . OA_EXPORT_DEFAULT_MODULE_PATH . '/' . $info['machine_name'];
+  }
+  // Either we are creating a new module at a different path or just adding the export to an existing module.
+  else {
+    // The path to where the module will be written as defined by the user.
+    $generate_path = $form_state['values']['generate_path'];
+    $module_path = DRUPAL_ROOT . '/' . $form_state['values']['generate_path'];
+  }
+
+  $_SESSION['oa_export'] = array();
+  // Store the module path so we have access after the batch runs.
+  // @todo: See if we can get rid of this by trying to call drupal_get_path('module', MODULE_NAME); in the batch finish function.
+  $_SESSION['oa_export']['module_path'] = $module_path;
+  $_SESSION['oa_export']['module'] = $info['machine_name'];
+  $_SESSION['oa_export']['type'] = 'new';
+
+  // We need to create directories and some files. Doing it here so if their creation isn't successful we can throw
+  // some errors.
+  if (!oa_export_create_directories($module_path . '/oa_export/files')) {
+    form_set_error(NULL, t("Couldn't create the module: @module_name at the path @module_path. Please check your permissions.", array(
+        '@module_name' => $info['machine_name'],
+        '@module_path' => $module_path,
+      )
+    ));
+  }
+  else {
+    // Set the directory for file export.
+    $_SESSION['oa_export']['files_directory'] = $module_path . '/oa_export/files';
+    // File types used to create a basic module.
+    $file_types = array('module', 'info', 'install');
+    foreach ($file_types as $extension) {
+      $success = oa_export_create_module_file($module_path, $info, $extension);
+      if (!$success) {
+        // Remove the oa_export directory that was created.
+        oa_export_cleanup($module_path);
+        // Set a form error.
+        form_set_error(NULL, t("Couldn't create the @module_name.@extension file at the path @module_path. Please check your permissions.", array(
+            '@extension' => $extension,
+            '@module_name' => $info['machine_name'],
+            '@module_path' => $module_path,
+          )
+        ));
+      }
+    }
+  }
+}
+
+/**
+ * Handles validation on the 'existing_module' form.
+ *
+ * @param $form
+ *   An associative array containing the structure of the form.
+ * @param $form_state
+ *   A keyed array containing the current state of the form.
+ */
+function oa_export_generate_existing_module_validate($form, &$form_state) {
+
+  // Get the path to the existing module.
+  $module_path = drupal_get_path('module', $form_state['values']['generate_path']);
+
+  $_SESSION['oa_export'] = array();
+
+  // Store the module path so we have access after the batch runs.
+  // @todo: See if we can get rid of this by trying to call drupal_get_path('module', MODULE_NAME); in the batch finish function.
+  $_SESSION['oa_export']['module_path'] = $module_path;
+  $_SESSION['oa_export']['module'] = $form_state['values']['generate_path'];
+  $_SESSION['oa_export']['type'] = 'existing';
+
+  // Try to create the oa_export directory. Set an error if we are unsuccessful.
+  if (!oa_export_create_directories($module_path . '/oa_export')) {
+    form_set_error(NULL, t("Couldn't create the oa_export directory in @module_name at the path @module_path. Please check your permissions.", array(
+        '@module_name' => $form_state['values']['generate_path'],
+        '@module_path' => $module_path,
+      )
+    ));
+  }
+  else {
+    // Try to create the files directory.
+    if (!oa_export_create_directories($module_path . '/oa_export/files')) {
+      // Remove the oa_export directory that was created.
+      oa_export_cleanup($module_path . '/oa_export');
+      form_set_error(NULL, t("Couldn't create a files directory in @module_name/oa_export at the path @module_path. Please check your permissions.", array(
+          '@module_name' => $form_state['values']['generate_path'],
+          '@module_path' => $module_path,
+        )
+      ));
+    }
+  }
+
+}
+
+/**
+ * The submit handler for the module generation form. This is what kicks off the batch process for the export.
+ *
+ * @param $form
+ *   An associative array containing the structure of the form.
+ * @param $form_state
+ *   A keyed array containing the current state of the form.
+ */
+function oa_export_generate_module_form_submit($form, &$form_state) {
+  $current_path = current_path();
+  $blueprint_tid = $form_state['values']['blueprint'];
+
+  $blueprint = taxonomy_term_load($blueprint_tid);
+  oa_export_batch_export($blueprint, 'module');
+  // Redirect the user to the current path.
+  batch_process($current_path);
+}
+
+/**
+ * Helper function to create the actual MODULE.module file.
+ *
+ * @param string $module_path
+ *   The full 'realpath' to where the module resides.
+ * @param array $info
+ *   Contains values needed to create the module keyed by keys used to create the MODULE.info file.
+ * @param $extension
+ *   The extension of the file being created, e.g. module, info, install.
+ *
+ * @return bool
+ *   Whether the file was successfully created or not.
+ */
+function oa_export_create_module_file($module_path, $info, $extension) {
+  $function = 'oa_export_file_content_' . $extension;
+  return $function($module_path, $info);
+}
+
+function oa_export_file_content_module($module_path, $info) {
+  $output = "<?php\n/**\n* @file\n* Drupal needs this blank file.\n*/\n";
+
+  if (file_put_contents($module_path . '/' . $info['machine_name'] . '.module', $output, FILE_APPEND) === FALSE) {
+    return FALSE;
+  }
+  else {
+    return TRUE;
+  }
+}
+
+/**
+ * Helper function to create the actual MODULE.info file.
+ *
+ * @param string $module_path
+ *   The full 'realpath' to where the module resides.
+ * @param array $info
+ *   Contains values needed to create the module keyed by keys used to create the MODULE.info file.
+ *
+ * @return bool
+ *   Whether the file was successfully created or not.
+ */
+function oa_export_file_content_info($module_path, $info) {
+  $keys = array('name', 'description', 'package', 'core', 'version');
+  $output = '';
+  foreach ($keys as $key) {
+    if (!empty($info[$key])) {
+      $output .= "$key = $info[$key]\n";
+    }
+  }
+  // We only need a dependency on oa_export for now.
+  $output .= "dependencies[] = oa_export";
+
+  if (file_put_contents($module_path . '/' . $info['machine_name'] . '.info', $output, FILE_APPEND|FILE_TEXT) === FALSE) {
+    return FALSE;
+  }
+  else {
+    return TRUE;
+  }
+}
+
+/**
+ * Helper function to create the actual MODULE.install file.
+ *
+ * @param string $module_path
+ *   The full 'realpath' to where the module resides.
+ * @param array $info
+ *   Contains values needed to create the module keyed by keys used to create the MODULE.info file.
+ *
+ * @return bool
+ *   Whether the file was successfully created or not.
+ */
+function oa_export_file_content_install($module_path, $info) {
+  $output = '';
+  $output .= "<?php\n/**\n* @file\n* Install, update and uninstall functions.\n*/\n";
+  $output .= "\n";
+  $output .= "function {$info['machine_name']}_install() {\n";
+  $output .= "  // This should be indented. For code.\n";
+  $output .= "}\n";
+
+  if (file_put_contents($module_path . '/' . $info['machine_name'] . '.install', $output, FILE_APPEND) === FALSE) {
+    return FALSE;
+  }
+  else {
+    return TRUE;
+  }
+}

--- a/oa_export.module.info.inc
+++ b/oa_export.module.info.inc
@@ -1,0 +1,87 @@
+<?php
+/**
+ * @file oa_export.module.info.inc
+ * Supports writing a new or updating an existing MODULE.info file.
+ */
+
+/**
+ * Helper function to return the values for the MODULE.info file for a new module.
+ *
+ * @param $form_state
+ *   A keyed array containing the current state of the form.
+ *
+ * @return array
+ */
+function oa_export_new_module_info($form_state) {
+  return array(
+    'name' => $form_state['values']['name'],
+    'description' => $form_state['values']['description'],
+    'core' => DRUPAL_CORE_COMPATIBILITY,
+    'package' => $form_state['values']['package'],
+    'version' => $form_state['values']['version'],
+  );
+}
+
+/**
+ * Helper function to create the actual MODULE.info file.
+ *
+ * @param string $module_path
+ *   The absolute path to the modules location.
+ * @param $form_state
+ *   A keyed array containing the current state of the form.
+ *
+ * @return bool
+ *   Whether the file was successfully created or not.
+ */
+function oa_export_create_new_info_file($module_path, $form_state) {
+  // Data the will be written to the info file.
+  $info = oa_export_new_module_info($form_state);
+  $output = '';
+  foreach ($info as $k => $v) {
+    $output .= "$k = $v\n";
+  }
+  // We only need a dependency on oa_export for now.
+  $output .= "dependencies[] = oa_export";
+
+  // Write the info file.
+  if (file_put_contents($module_path . '/' . $form_state['values']['machine_name'] . '.info', $output, FILE_APPEND|FILE_TEXT) === FALSE) {
+    return FALSE;
+  }
+  else {
+    return TRUE;
+  }
+}
+
+/**
+ * Updates an existing info file.
+ *
+ * @param string $module_path
+ *   The absolute path to the modules location.
+ * @param $form_state
+ *   A keyed array containing the current state of the form.
+ *
+ * @return bool
+ */
+function oa_export_update_existing_info_file($module_path, $form_state) {
+  $file = $module_path . '/' . $form_state['values']['machine_name'] . '.info';
+  // Check first to see if the module has an info file. It may not exist or just be an empty file.
+  if (!file_exists($file) || filesize($file) == 0) {
+    oa_export_create_new_info_file($module_path, $form_state);
+  }
+  else {
+    // Pattern to search for.
+    $pattern = "/dependencies[] = oa_export/";
+    // Check for "dependencies[] = oa_export" line in the info file
+    if (!oa_export_search_file($file, $pattern)) {
+      // We need to add a dependency on oa_export.
+      $output = 'dependencies[] = oa_export';
+      // Add the line to the info file.
+      if (file_put_contents($file, $output, FILE_APPEND|FILE_TEXT) === FALSE) {
+        return FALSE;
+      }
+      else {
+        return TRUE;
+      }
+    }
+  }
+}

--- a/oa_export.module.info.inc
+++ b/oa_export.module.info.inc
@@ -63,18 +63,18 @@ function oa_export_create_new_info_file($module_path, $form_state) {
  * @return bool
  */
 function oa_export_update_existing_info_file($module_path, $form_state) {
-  $file = $module_path . '/' . $form_state['values']['machine_name'] . '.info';
+  $file = $module_path . '/' . $form_state['values']['generate_path'] . '.info';
   // Check first to see if the module has an info file. It may not exist or just be an empty file.
   if (!file_exists($file) || filesize($file) == 0) {
     oa_export_create_new_info_file($module_path, $form_state);
   }
   else {
     // Pattern to search for.
-    $pattern = "/dependencies[] = oa_export/";
+    $pattern = "/dependencies\[\] = oa_export/";
     // Check for "dependencies[] = oa_export" line in the info file
     if (!oa_export_search_file($file, $pattern)) {
       // We need to add a dependency on oa_export.
-      $output = 'dependencies[] = oa_export';
+      $output = "\ndependencies[] = oa_export";
       // Add the line to the info file.
       if (file_put_contents($file, $output, FILE_APPEND|FILE_TEXT) === FALSE) {
         return FALSE;
@@ -82,6 +82,10 @@ function oa_export_update_existing_info_file($module_path, $form_state) {
       else {
         return TRUE;
       }
+    }
+    else {
+      // The module already has a dependency on oa_export.
+      return TRUE;
     }
   }
 }

--- a/oa_export.module.install.inc
+++ b/oa_export.module.install.inc
@@ -57,7 +57,7 @@ function oa_export_create_new_install_file($module_path, $form_state) {
  *    Whether the file was successfully written to..
  */
 function oa_export_update_existing_install_file($module_path, $form_state) {
-  $module_name = $form_state['values']['machine_name'];
+  $module_name = $form_state['values']['generate_path'];
   $file = $module_path . '/' . $module_name . '.install';
   // We need to find out if there are any existing update hooks.
   // Find out what update, if any, the module has run so we can get the next hook_update_N() version.
@@ -83,7 +83,8 @@ function oa_export_update_existing_install_file($module_path, $form_state) {
     }
     else {
       // We didn't find hook_install(). Let's check for existing updates.
-      // Pattern used to find implementations of hook_update_N().
+      // Pattern used to find implementations of hook_update_N(). Using a pattern here instead of relying on what Drupal
+      // found for a schema version in case the module isn't enabled yet.
       $pattern = "/function " . $module_name . "_update_([0-9]{4})\(\) {/";
       // Search the install file for implementations of hook_update_N().
       if ($results = oa_export_search_file($file, $pattern)) {
@@ -95,6 +96,7 @@ function oa_export_update_existing_install_file($module_path, $form_state) {
         return oa_export_write_update_hook($module_path, $module_name, $new_version);
       }
     }
+    return TRUE;
   }
 }
 
@@ -112,7 +114,7 @@ function oa_export_update_existing_install_file($module_path, $form_state) {
  */
 function oa_export_write_hook_install($module_path, $module_name, $version) {
   $output = '';
-  $output .= "\n/**\n* @file\n* Install, update and uninstall functions.\n*/\n";
+  $output .= "<?php\n/**\n* @file\n* Install, update and uninstall functions.\n*/\n";
   $output .= "\n";
   $output .= "/**\n* Implements hook_install().\n*/\n";
   $output .= "function {$module_name}_install() {\n";
@@ -129,6 +131,8 @@ function oa_export_write_hook_install($module_path, $module_name, $version) {
 }
 
 /**
+ * Writes an update hook for the MODULE.install file.
+ *
  * @param string $module_path
  *   The absolute path to the modules location.
  * @param array $module_name

--- a/oa_export.module.install.inc
+++ b/oa_export.module.install.inc
@@ -1,0 +1,161 @@
+<?php
+/**
+ * @file oa_export.module.install.inc
+ * Supports writing a new or updating an existing MODULE.install file.
+ */
+
+/**
+ * Builds a schema version for an update hook written to a new MODULE.install file.
+ *
+ * @param int $version
+ *   An existing schema version if one exists.
+ *
+ * @return string
+ *   The schema version for an update hook in a new MODULE.install file.
+ */
+function oa_export_get_new_schema_version($version = 0) {
+  if ($version > 0) {
+    return $version + 1;
+  }
+  list($core) = explode('.', DRUPAL_CORE_COMPATIBILITY);
+  // The schema version to use for hook_update_N().
+  return $core . '000';
+}
+
+/**
+ * Creates a new install file for a module.
+ *
+ * @param string $module_path
+ *   The absolute path to the modules location.
+ * @param $form_state
+ *   A keyed array containing the current state of the form.
+ *
+ * @return bool
+ *   Whether the file was successfully created or not.
+ */
+function oa_export_create_new_install_file($module_path, $form_state) {
+  $module_name = $form_state['values']['machine_name'];
+  // The schema version to use for hook_update_N().
+  $version = oa_export_get_new_schema_version();
+  // Write an implementation of hook_install().
+  if ($success = oa_export_write_hook_install($module_path, $module_name, $version)) {
+    // Write an implementation of hook_update_N().
+    $success = oa_export_write_update_hook($module_path, $module_name, $version);
+  }
+  return $success;
+}
+
+/**
+ * Reads through an existing install file so we better know how to write our changes to it.
+ *
+ * @param string $module_path
+ *   The absolute path to the modules location.
+ * @param $form_state
+ *   A keyed array containing the current state of the form.
+ *
+ * @return bool
+ *    Whether the file was successfully written to..
+ */
+function oa_export_update_existing_install_file($module_path, $form_state) {
+  $module_name = $form_state['values']['machine_name'];
+  $file = $module_path . '/' . $module_name . '.install';
+  // We need to find out if there are any existing update hooks.
+  // Find out what update, if any, the module has run so we can get the next hook_update_N() version.
+  include_once(DRUPAL_ROOT . '/includes/install.inc');
+  $schema_version = drupal_get_installed_schema_version($module_name);
+
+  // Check first to see if the module has an install file. It may not exist or just be an empty file.
+  if (!file_exists($file) || filesize($file) == 0) {
+    oa_export_create_new_install_file($module_path, $form_state);
+  }
+  // The file exists and isn't empty.
+  else {
+    // Pattern used to find hook_install().
+    $pattern = "/function " . $module_name . "_install\(\) {/";
+    // Search the install file for an implementation of hook_install().
+    if ($result = oa_export_search_file($file, $pattern)) {
+      // Check to see the schema version is greater than 0. This lets us know if the module is enabled and the install
+      // file contains no previous update hooks. We can just add a new update hook.
+      if ($schema_version > SCHEMA_INSTALLED) {
+        $new_version = oa_export_get_new_schema_version();
+        return oa_export_write_update_hook($module_path, $module_name, $new_version);
+      }
+    }
+    else {
+      // We didn't find hook_install(). Let's check for existing updates.
+      // Pattern used to find implementations of hook_update_N().
+      $pattern = "/function " . $module_name . "_update_([0-9]{4})\(\) {/";
+      // Search the install file for implementations of hook_update_N().
+      if ($results = oa_export_search_file($file, $pattern)) {
+        // Get the latest version returned from the file.
+        $latest_version = end($results);
+        // Get the new version.
+        $new_version = oa_export_get_new_schema_version($latest_version);
+        // Write the update hook to the install file.
+        return oa_export_write_update_hook($module_path, $module_name, $new_version);
+      }
+    }
+  }
+}
+
+/**
+ * Helper function to create the actual MODULE.install file.
+ *
+ * @param string $module_path
+ *   The absolute path to the modules location.
+ * @param array $module_name
+ *   The machine_name of the module.
+ * @param int $version
+ *
+ * @return bool
+ *   Whether the file contents were successfully written or not.
+ */
+function oa_export_write_hook_install($module_path, $module_name, $version) {
+  $output = '';
+  $output .= "\n/**\n* @file\n* Install, update and uninstall functions.\n*/\n";
+  $output .= "\n";
+  $output .= "/**\n* Implements hook_install().\n*/\n";
+  $output .= "function {$module_name}_install() {\n";
+  $output .= "  // Call our update hook.\n";
+  $output .= "  {$module_name}_update_{$version}();\n";
+  $output .= "}\n";
+
+  if (file_put_contents($module_path . '/' . $module_name . '.install', $output, FILE_APPEND) === FALSE) {
+    return FALSE;
+  }
+  else {
+    return TRUE;
+  }
+}
+
+/**
+ * @param string $module_path
+ *   The absolute path to the modules location.
+ * @param array $module_name
+ *   The machine_name of the module.
+ * @param $version
+ *
+ * @return bool
+ *   Whether the file contents were successfully written or not.
+ */
+function oa_export_write_update_hook($module_path, $module_name, $version) {
+  $output = "";
+  $output .= "\n/**\n* Implements hook_update_N().\n* Imports a blueprint.\n*/\n";
+  $output .= "function {$module_name}_update_{$version}() {\n";
+  $output .= "  // Check for the oa_export directory.\n";
+  $output .= "  if (file_exists('oa_export')) {\n";
+  $output .= "    \$module = '" . $module_name . "';\n";
+  $output .= "    // Get the full path to the module directory.\n";
+  $output .= "    \$path = drupal_get_path('module', \$module) . '/' . OA_EXPORT_FILES;\n";
+  $output .= "    // Start the import.\n";
+  $output .= "    oa_export_batch_import(\$path, 'module');\n";
+  $output .= "  }\n";
+  $output .= "}\n";
+
+  if (file_put_contents($module_path . '/' . $module_name . '.install', $output, FILE_APPEND) === FALSE) {
+    return FALSE;
+  }
+  else {
+    return TRUE;
+  }
+}

--- a/oa_export.module.module.inc
+++ b/oa_export.module.module.inc
@@ -1,0 +1,53 @@
+<?php
+/**
+ * @file oa_export.module.module.inc
+ * Supports writing a new MODULE.module file.
+ */
+
+/**
+ * Adds an empty module file when creating a new module.
+ *
+ * @param string $module_path
+ *   The absolute path to the modules location.
+ * @param $form_state
+ *   A keyed array containing the current state of the form.
+ *
+ * @return bool
+ */
+function oa_export_create_new_module_file($module_path, $form_state) {
+  $module_name = $form_state['values']['machine_name'];
+  $file = $module_path . '/' . $module_name . '.module';
+  // If the module doesn't exist we just add a comment to the .module file.
+  $output = "<?php\n/**\n* @file\n* Drupal needs this blank file.\n*/\n";
+
+  // Write to the file.
+  if (file_put_contents($file, $output, FILE_APPEND) === FALSE) {
+    return FALSE;
+  }
+  else {
+    return TRUE;
+  }
+}
+
+/**
+ * This is here in case an empty module file exists.
+ *
+ * @param string $module_path
+ *   The absolute path to the modules location.
+ * @param $form_state
+ *   A keyed array containing the current state of the form.
+ *
+ * @return bool
+ */
+function oa_export_update_existing_module_file($module_path, $form_state) {
+  $module_name = $form_state['values']['machine_name'];
+  $file = $module_path . '/' . $module_name . '.module';
+  // Check first to see if the module has a module file. It may not exist or just be an empty file.
+  if (!file_exists($file) || filesize($file) == 0) {
+    oa_export_create_new_module_file($module_path, $form_state);
+  }
+  // The file exists and is not empty so just move on.
+  else {
+    return TRUE;
+  }
+}


### PR DESCRIPTION
This allows two options as of now:
- The export can be added as a new module and placed where the user sees fit.
  - The import will occur when the module is installed on the other system.  
- The export can be added to an existing module.
  - The import will occur when the user runs a database update.

This still requires logic in hook_install(). I will add that once I've had a chance to pull these changes in to my 'import' environment to test imports.
