### PR TITLE
If comments are not enabled the query fails.

### DIFF
--- a/oa_export.module
+++ b/oa_export.module
@@ -161,13 +161,18 @@ function oa_export_import_decode_data($path) {
  *   The comment ids.
  */
 function oa_export_get_comments($nid) {
-  $comments = db_select('comment', 'c')
-    ->fields('c', array('cid', 'nid'))
-    ->condition('nid', $nid, '=')
-    ->execute()
-    ->fetchAllKeyed();
+  if (db_table_exists('comment')) {
+    $comments = db_select('comment', 'c')
+      ->fields('c', array('cid', 'nid'))
+      ->condition('nid', $nid, '=')
+      ->execute()
+      ->fetchAllKeyed();
 
-  return array_keys($comments);
+    return array_keys($comments);
+  }
+  else {
+    return array();
+  }
 }
 
 /**


### PR DESCRIPTION
Hadn't run across this yet since Atrium enables the comment module. In Bassmaster we aren't enabling comments.
